### PR TITLE
Replace Guava with Caffeine.

### DIFF
--- a/actors/infinispan-cluster/src/main/resources/conf/jgroups.xml
+++ b/actors/infinispan-cluster/src/main/resources/conf/jgroups.xml
@@ -26,7 +26,6 @@
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   -->
-
 <!--
   Default stack using IP multicasting. It is similar to the "udp"
   stack in stacks.xml, but doesn't use streaming state transfer and flushing

--- a/actors/runtime/pom.xml
+++ b/actors/runtime/pom.xml
@@ -94,9 +94,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.2.6</version>
         </dependency>
 
         <dependency>

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -115,6 +115,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.TimeUnit;
@@ -450,7 +451,6 @@ public class Stage implements Startable, ActorRuntime
             finder.start().join();
         }
 
-
         cacheManager = new ResponseCaching();
 
         hosting.setNodeType(mode == StageMode.HOST ? NodeCapabilities.NodeTypeEnum.SERVER : NodeCapabilities.NodeTypeEnum.CLIENT);
@@ -684,7 +684,9 @@ public class Stage implements Startable, ActorRuntime
                 }
 
                 // Skip this actor if it is marked NeverDeactivate
-                if(RemoteReference.getInterfaceClass(actorEntry.getRemoteReference()).isAnnotationPresent(NeverDeactivate.class)) continue;
+                if (RemoteReference.getInterfaceClass(actorEntry.getRemoteReference()).isAnnotationPresent(NeverDeactivate.class)) {
+                    continue;
+                }
 
                 if (clock().millis() - actorEntry.getLastAccess() > maxAge)
                 {

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/ActorEntry.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/ActorEntry.java
@@ -164,7 +164,7 @@ public class ActorEntry<T extends AbstractActor> extends ActorBaseEntry<T>
             {
                 return Task.done();
             }
-            return executionSerializer.offerJob(key, () -> doDeactivate(), 1000);
+            return executionSerializer.offerJob(key, () -> doDeactivate(), 10000);
         }
         catch (Throwable ex)
         {

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Messaging.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Messaging.java
@@ -67,7 +67,7 @@ public class Messaging extends HandlerAdapter implements Startable
 
     private final LongAdder networkMessagesReceived = new LongAdder();
     private final LongAdder responsesReceived = new LongAdder();
-    private static Timer timer = new Timer("Messaging timer");
+    private static Timer timer = new Timer("Messaging timer", true);
     private BasicRuntime runtime;
 
 

--- a/actors/runtime/src/main/java/cloud/orbit/actors/streams/simple/SimpleStreamExtension.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/streams/simple/SimpleStreamExtension.java
@@ -28,26 +28,23 @@
 
 package cloud.orbit.actors.streams.simple;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
 import cloud.orbit.actors.Actor;
 import cloud.orbit.actors.extensions.ActorExtension;
 import cloud.orbit.actors.extensions.StreamProvider;
 import cloud.orbit.actors.streams.AsyncStream;
 import cloud.orbit.concurrent.ConcurrentHashSet;
-import cloud.orbit.exception.UncheckedException;
-
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-
-import java.util.concurrent.ExecutionException;
 
 public class SimpleStreamExtension implements ActorExtension, StreamProvider
 {
     private String name;
-    private Cache<Actor, SimpleStreamProxyObject> weakCache = CacheBuilder.newBuilder()
+    private final Cache<Actor, SimpleStreamProxyObject> weakCache = Caffeine.newBuilder()
             .weakValues()
             .build();
 
-    private ConcurrentHashSet<SimpleStreamProxyObject> hardRefs = new ConcurrentHashSet<>();
+    private final ConcurrentHashSet<SimpleStreamProxyObject> hardRefs = new ConcurrentHashSet<>();
 
 
     public SimpleStreamExtension()
@@ -78,15 +75,8 @@ public class SimpleStreamExtension implements ActorExtension, StreamProvider
 
     public <T> SimpleStreamProxyObject<T> getSubscriber(final SimpleStream streamActorRef)
     {
-        try
-        {
-            //noinspection unchecked
-            return weakCache.get(streamActorRef, () -> new SimpleStreamProxyObject<T>(this, streamActorRef));
-        }
-        catch (ExecutionException e)
-        {
-            throw new UncheckedException(e);
-        }
+        //noinspection unchecked
+        return weakCache.get(streamActorRef, o -> new SimpleStreamProxyObject<T>(this, streamActorRef));
     }
 
     ConcurrentHashSet<SimpleStreamProxyObject> getHardRefs()

--- a/actors/test/actor-tests/pom.xml
+++ b/actors/test/actor-tests/pom.xml
@@ -53,11 +53,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/actors/test/actor-tests/src/main/java/cloud/orbit/actors/test/FakeGroup.java
+++ b/actors/test/actor-tests/src/main/java/cloud/orbit/actors/test/FakeGroup.java
@@ -37,9 +37,9 @@ import cloud.orbit.exception.UncheckedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -50,7 +50,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
@@ -58,7 +57,7 @@ public class FakeGroup
 {
     private static final Logger logger = LoggerFactory.getLogger(FakeGroup.class);
 
-    private static LoadingCache<String, FakeGroup> groups = CacheBuilder.newBuilder()
+    private static final LoadingCache<String, FakeGroup> groups = Caffeine.newBuilder()
             .weakValues()
             .build(new CacheLoader<String, FakeGroup>()
             {
@@ -69,11 +68,11 @@ public class FakeGroup
                 }
             });
 
-    private Map<NodeAddress, FakeClusterPeer> currentChannels = new HashMap<>();
+    private final Map<NodeAddress, FakeClusterPeer> currentChannels = new HashMap<>();
 
     private final Object topologyMutex = new Object();
     @SuppressWarnings("rawtypes")
-    private LoadingCache<String, ConcurrentMap> maps = CacheBuilder.newBuilder()
+    private final LoadingCache<String, ConcurrentMap> maps = Caffeine.newBuilder()
             .build(new CacheLoader<String, ConcurrentMap>()
             {
                 @Override
@@ -149,27 +148,13 @@ public class FakeGroup
 
     public static FakeGroup get(final String clusterName)
     {
-        try
-        {
-            return groups.get(clusterName);
-        }
-        catch (ExecutionException e)
-        {
-            throw new UncheckedException(e);
-        }
+        return groups.get(clusterName);
     }
 
     @SuppressWarnings("unchecked")
     public <K, V> ConcurrentMap<K, V> getCache(final String name)
     {
-        try
-        {
-            return maps.get(name);
-        }
-        catch (ExecutionException e)
-        {
-            throw new UncheckedException(e);
-        }
+        return maps.get(name);
     }
 
     public Map<String, ConcurrentMap> getCaches()

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/CacheResponseTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/CacheResponseTest.java
@@ -28,6 +28,12 @@
 
 package cloud.orbit.actors.test;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.benmanes.caffeine.cache.Ticker;
+
 import cloud.orbit.actors.Actor;
 import cloud.orbit.actors.Stage;
 import cloud.orbit.actors.runtime.NodeCapabilities;
@@ -35,12 +41,6 @@ import cloud.orbit.actors.runtime.ResponseCaching;
 import cloud.orbit.actors.test.actors.CacheResponse;
 import cloud.orbit.actors.test.actors.CacheResponseActor;
 import cloud.orbit.exception.UncheckedException;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.google.common.base.Ticker;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -55,7 +55,7 @@ public class CacheResponseTest extends ActorBaseTest
     /**
      * A Ticker which does not progress time unless called with advanceMillis
      */
-    private class CacheResponseTestTicker extends Ticker
+    private class CacheResponseTestTicker implements Ticker
     {
         private long elapsedMillis;
 
@@ -218,6 +218,7 @@ public class CacheResponseTest extends ActorBaseTest
     @Before
     public void initializeCacheManager()
     {
+        ResponseCaching.setCacheExecutor(Runnable::run);
         ResponseCaching.setDefaultCacheTicker(null);
     }
 

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/serialization/ReferenceSerializationTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/serialization/ReferenceSerializationTest.java
@@ -43,10 +43,9 @@ import cloud.orbit.concurrent.Task;
 
 import org.junit.Test;
 
-import com.google.common.collect.Sets;
-
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -163,8 +162,7 @@ public class ReferenceSerializationTest extends ActorBaseTest
         SomePlayer somePlayer = Actor.getReference(SomePlayer.class, "101");
         somePlayer.joinMatch(someMatch).join();
 
-
-        Set<Class<?>> validClasses = Sets.newHashSet(RemoteKey.class, NodeAddressImpl.class, String.class);
+        Set<Class<?>> validClasses = new HashSet<>(Arrays.asList(RemoteKey.class, NodeAddressImpl.class, String.class));
 
         for (Map.Entry e : FakeGroup.get(clusterName).getCaches().entrySet())
         {

--- a/actors/test/benchmarks/pom.xml
+++ b/actors/test/benchmarks/pom.xml
@@ -94,7 +94,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jmh.version>1.11.2</jmh.version>
+        <jmh.version>1.12</jmh.version>
         <javac.target>1.8</javac.target>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>

--- a/actors/test/benchmarks/src/main/java/cloud/orbit/actors/test/SingleNodeBenchmark.java
+++ b/actors/test/benchmarks/src/main/java/cloud/orbit/actors/test/SingleNodeBenchmark.java
@@ -91,6 +91,8 @@ public class SingleNodeBenchmark
     @Setup
     public void setup()
     {
+        System.setProperty("java.net.preferIPv4Stack", "true");
+
         System.out.println("Create stage");
         stage = createStage();
         if (profile)

--- a/commons/src/main/java/cloud/orbit/concurrent/ForwardingExecutorService.java
+++ b/commons/src/main/java/cloud/orbit/concurrent/ForwardingExecutorService.java
@@ -1,0 +1,120 @@
+/*
+ Copyright (C) 2016 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.concurrent;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * @author Johno Crawford (johno@sulake.com)
+ */
+public class ForwardingExecutorService<T extends ExecutorService> implements ExecutorService
+{
+    protected final T delegate;
+
+    public ForwardingExecutorService(T delegate)
+    {
+        if (delegate == null)
+        {
+            throw new IllegalArgumentException("Executor must not be null!");
+        }
+        this.delegate = delegate;
+    }
+
+    public void shutdown()
+    {
+        delegate.shutdown();
+    }
+
+    public List<Runnable> shutdownNow()
+    {
+        return delegate.shutdownNow();
+    }
+
+    public boolean isShutdown()
+    {
+        return delegate.isShutdown();
+    }
+
+    public boolean isTerminated()
+    {
+        return delegate.isTerminated();
+    }
+
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException
+    {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    public <T> Future<T> submit(Callable<T> task)
+    {
+        return delegate.submit(task);
+    }
+
+    public <T> Future<T> submit(Runnable task, T result)
+    {
+        return delegate.submit(task, result);
+    }
+
+    public Future<?> submit(Runnable task)
+    {
+        return delegate.submit(task);
+    }
+
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException
+    {
+        return delegate.invokeAll(tasks);
+    }
+
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException
+    {
+        return delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException
+    {
+        return delegate.invokeAny(tasks);
+    }
+
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException
+    {
+        return delegate.invokeAny(tasks, timeout, unit);
+    }
+
+    public void execute(Runnable command)
+    {
+        delegate.execute(command);
+    }
+}

--- a/commons/src/main/java/cloud/orbit/concurrent/Task.java
+++ b/commons/src/main/java/cloud/orbit/concurrent/Task.java
@@ -66,8 +66,7 @@ public class Task<T> extends CompletableFuture<T>
     private static Void NIL = null;
 
     private static Executor commonPool = ExecutorUtils.newScalingThreadPool(100);
-    private static final ScheduledExecutorService schedulerExecutor =
-            Executors.newScheduledThreadPool(10);
+    private static ScheduledExecutorService schedulerExecutor = Executors.newScheduledThreadPool(10);
 
     // TODO: make all callbacks async by default and using the current executor
     // what "current executor' means will have to be defined.


### PR DESCRIPTION
Caffeine vs Guava (old benchmarks below, see commit for updated benchmarks)

Caffeine 

Benchmark                                         Mode  Cnt        Score       Error  Units
SingleNodeBenchmark.requestThroughput            thrpt  100  3013608.693 ± 29675.239  ops/s
SingleNodeBenchmark.avgRequestTime_batched        avgt  100        1.242 ±     0.007  us/op
SingleNodeBenchmark.avgRequestTime_singleThread   avgt  100        4.279 ±     0.060  us/op

Benchmark                                         Mode  Cnt        Score       Error  Units
SingleNodeBenchmark.requestThroughput            thrpt  100  3085224.027 ± 36085.998  ops/s
SingleNodeBenchmark.avgRequestTime_batched        avgt  100        1.269 ±     0.006  us/op
SingleNodeBenchmark.avgRequestTime_singleThread   avgt  100        4.142 ±     0.074  us/op

Guava

Benchmark                                         Mode  Cnt        Score       Error  Units
SingleNodeBenchmark.requestThroughput            thrpt  100  3152836.327 ± 35103.067  ops/s
SingleNodeBenchmark.avgRequestTime_batched        avgt  100        1.239 ±     0.010  us/op
SingleNodeBenchmark.avgRequestTime_singleThread   avgt  100        4.081 ±     0.078  us/op