### PR TITLE
infinispan-cluster does not require infinispan-embedded to run and ca…

### DIFF
--- a/actors/infinispan-cluster/pom.xml
+++ b/actors/infinispan-cluster/pom.xml
@@ -49,8 +49,8 @@
 
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-embedded</artifactId>
-            <version>8.2.0.Final</version>
+            <artifactId>infinispan-core</artifactId>
+            <version>8.1.3.Final</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
…n be replaced with the smaller dependency infinispan-core.