### PR TITLE
Ensure EA Async is not a transitive dependency in orbit

### DIFF
--- a/actors/core/pom.xml
+++ b/actors/core/pom.xml
@@ -97,10 +97,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.ea.async</groupId>
-            <artifactId>ea-async</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.21</version>

--- a/actors/pom.xml
+++ b/actors/pom.xml
@@ -60,6 +60,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <artifactId>orbit-commons</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.ea.async</groupId>
+            <artifactId>ea-async</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -68,11 +73,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
                 <version>${asm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.ea.async</groupId>
-                <artifactId>ea-async</artifactId>
-                <version>${ea.async.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/actors/pom.xml
+++ b/actors/pom.xml
@@ -69,6 +69,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <artifactId>asm</artifactId>
                 <version>${asm.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.ea.async</groupId>
+                <artifactId>ea-async</artifactId>
+                <version>${ea.async.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -201,7 +201,7 @@ public class Stage implements Startable, ActorRuntime
     static
     {
         // this is here to help people testing the orbit source code.
-        // because Await.init is removed by the build time bytecode instrumentation.
+        // because Async.init is removed by the build time bytecode instrumentation.
         Async.init();
     }
 

--- a/actors/test/actor-tests/pom.xml
+++ b/actors/test/actor-tests/pom.xml
@@ -73,6 +73,5 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <scope>test</scope>
             <version>1.7.21</version>
         </dependency>
-
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.ea.async</groupId>
+            <artifactId>ea-async</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
             </dependency>
-
+            <dependency>
+                <groupId>com.ea.async</groupId>
+                <artifactId>ea-async</artifactId>
+                <version>${ea.async.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -68,11 +72,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.ea.async</groupId>
-            <artifactId>ea-async</artifactId>
-            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.ea.async</groupId>
-                <artifactId>ea-async</artifactId>
-                <version>${ea.async.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>


### PR DESCRIPTION
I want to make sure that Orbit does not pull in async as a transitive dependency. 
Application developers should include async if they want to use it, not be forced to use it.