### PR TITLE
Removed caffeine Ticker setter from ResponseCaching

### DIFF
--- a/actors/test/actor-tests/src/main/java/cloud/orbit/actors/test/FakeClock.java
+++ b/actors/test/actor-tests/src/main/java/cloud/orbit/actors/test/FakeClock.java
@@ -66,7 +66,7 @@ public class FakeClock extends Clock
     {
         if (stopped)
         {
-            return millis.incrementAndGet();
+            return millis.get();
         }
         else
         {

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/CacheResponseCloneTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/CacheResponseCloneTest.java
@@ -167,7 +167,7 @@ public class CacheResponseCloneTest extends ActorBaseTest
     @Before
     public void initializeCacheManager()
     {
-        ResponseCaching.setDefaultCacheTicker(null);
+        ResponseCaching.setClock(null);
     }
 
     @After


### PR DESCRIPTION
Motivation:

ResponseCaching exposed a public setter with a reference to a transient dependency.

Modifications:

Replaced custom ticker with fake clock.

Result:

No dependency leakage.