### PR TITLE
Kyro cloner to support no-arg classes

### DIFF
--- a/actors/runtime/pom.xml
+++ b/actors/runtime/pom.xml
@@ -55,12 +55,17 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                             <artifactSet>
                                 <includes>
                                     <include>com.esotericsoftware:*</include>
+                                    <include>de.javakaffee:kryo-serializers</include>
                                     <include>org.objenesis:*</include>
                                     <include>org.ow2.asm:asm</include>
                                     <include>com.github.ben-manes.caffeine:caffeine</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
+                                <relocation>
+                                    <pattern>de.javakaffee.</pattern>
+                                    <shadedPattern>cloud.orbit.runtime.shaded.de.javakaffee.</shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>com.esotericsoftware.</pattern>
                                     <shadedPattern>cloud.orbit.runtime.shaded.com.esotericsoftware.</shadedPattern>
@@ -108,6 +113,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <groupId>com.esotericsoftware</groupId>
             <artifactId>kryo</artifactId>
             <version>3.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>de.javakaffee</groupId>
+            <artifactId>kryo-serializers</artifactId>
+            <version>0.37</version>
         </dependency>
 
         <dependency>

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/ExceptionalTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/ExceptionalTest.java
@@ -36,8 +36,6 @@ import cloud.orbit.concurrent.Task;
 
 import org.junit.Test;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -52,8 +50,6 @@ public class ExceptionalTest extends ActorBaseTest
         Task<String> justRespond();
 
         Task<String> justThrowAnException();
-
-        Task<String> justThrowANonSerializableException();
     }
 
     @SuppressWarnings("rawtypes")
@@ -67,15 +63,6 @@ public class ExceptionalTest extends ActorBaseTest
         public Task<String> justThrowAnException()
         {
             throw new RuntimeException("as requested, one exception!");
-        }
-
-        @Override
-        public Task<String> justThrowANonSerializableException()
-        {
-            throw new RuntimeException()
-            {
-                NonSerializableThing a = new NonSerializableThing();
-            };
         }
     }
 
@@ -135,22 +122,6 @@ public class ExceptionalTest extends ActorBaseTest
         //assertEquals(RuntimeException.class, ex.getClass());
         assertTrue(ex instanceof RuntimeException);
         assertTrue(ex.getMessage(), ex.getMessage().endsWith("as requested, one exception!"));
-    }
-
-    @Test(timeout = 30_000L)
-    public void checkingNonSerializable() throws ExecutionException, InterruptedException
-    {
-        // checks if exceptions with stuff that's not serializable get their stacktrace sent back to the caller.
-        Stage stage1 = createStage();
-        final ExceptionalThing ref = Actor.getReference(ExceptionalThing.class, "0");
-
-        final Throwable ex = expectException(() -> ref.justThrowANonSerializableException());
-
-        final StringWriter stringWriter = new StringWriter();
-        ex.printStackTrace(new PrintWriter(stringWriter));
-        assertTrue(stringWriter.toString().contains("ExceptionalTest.java:"));
-        assertTrue(stringWriter.toString().contains("NonSerializableThing"));
-        assertTrue(stringWriter.toString().contains("justThrowANonSerializableException"));
     }
 
     //@Test


### PR DESCRIPTION
Motivation:

Kyro cloner does not support no-arg classes.

Modifications:

Configure Kryo to first try to find and use a no-arg constructor and if it fails to do so, fallback to StdInstantiatorStrategy provided by objenesis.

Result:

True immutable objects without no-arg constructors can now be used as Orbit remote objects.