### PR TITLE
Dirty local caches.

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/NodeCapabilities.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/NodeCapabilities.java
@@ -60,4 +60,7 @@ public interface NodeCapabilities extends ActorObserver
 
     @OneWay
     Task<Void> moved(RemoteReference<?> actorKey, NodeAddress oldAddress, NodeAddress newAddress);
+
+    @OneWay
+    Task<Void> remove(RemoteReference<?> actorKey);
 }

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/SomeActor.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/SomeActor.java
@@ -29,6 +29,7 @@
 package cloud.orbit.actors.test.actors;
 
 import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.annotation.OnlyIfActivated;
 import cloud.orbit.concurrent.Task;
 
 import java.util.UUID;
@@ -36,6 +37,9 @@ import java.util.UUID;
 public interface SomeActor extends Actor
 {
     Task<String> sayHello(String greeting);
+
+    @OnlyIfActivated
+    Task<String> sayHelloOnlyIfActivated();
 
     Task<UUID> getUniqueActivationId();
 

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/SomeActorImpl.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/SomeActorImpl.java
@@ -46,6 +46,12 @@ public class SomeActorImpl extends AbstractActor implements SomeActor
     }
 
     @Override
+    public Task<String> sayHelloOnlyIfActivated()
+    {
+        return Task.fromValue("hello");
+    }
+
+    @Override
     public Task<UUID> getUniqueActivationId()
     {
         return Task.fromValue(uniqueActivationId);


### PR DESCRIPTION
Dirty local cache
Motivation:

There are some cases where nodes will not be informed if an actor has moved or deactivated.

Modifications:

Notify invocation node if actor has moved.
Clear actor reference from local cache when actor deactivates.
Unit test for checking dirty local cache.

Result:

Correct behaviour when using OnlyIfActivated annotation in multi-JVM cluster.