### PR TITLE
Make AbstractActor member variables protected

### DIFF
--- a/actors/core/src/main/java/cloud/orbit/actors/runtime/AbstractActor.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/runtime/AbstractActor.java
@@ -48,12 +48,12 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class AbstractActor<T>
 {
-    T state;
-    StorageExtension stateExtension;
-    RemoteReference<?> reference;
-    Logger logger;
-    ActorRuntime runtime;
-    Object activation;
+    protected T state;
+    protected StorageExtension stateExtension;
+    protected RemoteReference<?> reference;
+    protected Logger logger;
+    protected ActorRuntime runtime;
+    protected Object activation;
 
     protected AbstractActor()
     {


### PR DESCRIPTION
Make member variables protected to be able to override methods of AbstractActor. 