### PR TITLE
onClusterViewChanged needs to be thread safe, apparently.

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
@@ -231,7 +231,6 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
                 nodeInfo = new NodeInfo(a);
                 nodeInfo.nodeCapabilities = stage.getRemoteObserverReference(a, NodeCapabilities.class, "");
                 nodeInfo.active = true;
-                activeNodes.put(a, nodeInfo);
                 justAddedNodes.add(nodeInfo);
             }
             newNodes.put(a, nodeInfo);


### PR DESCRIPTION
Could be related to updating to the latest GA infinispan ( 8.2.4.Final ) but it is an obvious bug in the Hosting cluster view changed implementation. 