### PR TITLE
Notify cluster when node is shutting down

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -691,7 +691,7 @@ public class Stage implements Startable, ActorRuntime
         // * stop the network
 
         logger.debug("start stopping pipeline");
-        await(pipeline.write(NodeCapabilities.NodeState.STOPPING));
+        await(hosting.notifyStateChange());
 
         logger.debug("stopping actors");
         await(stopActors());

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
@@ -135,8 +135,9 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
 
     public Task<?> notifyStateChange()
     {
-        return Task.allOf(activeNodes.values().stream().map(info ->
-                info.nodeCapabilities.nodeModeChanged(clusterPeer.localAddress(), stage.getState())));
+        return Task.allOf(activeNodes.values().stream()
+                .filter(nodeInfo -> !nodeInfo.address.equals(clusterPeer.localAddress()) && nodeInfo.state == NodeState.RUNNING)
+                .map(info -> info.nodeCapabilities.nodeModeChanged(clusterPeer.localAddress(), stage.getState()).exceptionally(throwable -> null)));
     }
 
     public NodeAddress getNodeAddress()
@@ -342,8 +343,6 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
         }
 
         // There is no existing activation at this time or it's not in the local cache
-
-
         final Task<NodeAddress> async = Task.supplyAsync(() ->
         {
             NodeAddress nodeAddress = null;

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/ShutdownTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/ShutdownTest.java
@@ -90,6 +90,8 @@ public class ShutdownTest extends ActorBaseTest
         logger.info("stage2: " + stage2);
 
         stage1.stop().join();
+
+        stage2.bind();
         Actor.getReference(Shut.class, "0").doSomething().join();
     }
 

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/samples/DemoTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/samples/DemoTest.java
@@ -143,6 +143,7 @@ public class DemoTest extends ActorBaseTest
         stage2.cleanup().join();
         stage1.cleanup().join();
         stage1.stop().join();
+        stage2.bind();
         assertEquals(100, bank.getBalance().join().intValue());
 
         dumpMessages();

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/streams/StreamPersistenceTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/streams/StreamPersistenceTest.java
@@ -103,6 +103,8 @@ public class StreamPersistenceTest extends ActorBaseTest
         // the actor will remain alive in stage 2
         stage1.stop().join();
 
+        stage2.bind();
+
         // the stream will be activated again in stage 2
         test.publish("hello3");
         assertEquals("hello3", queue.poll(10, TimeUnit.SECONDS));

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/streams/StreamTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/streams/StreamTest.java
@@ -73,7 +73,7 @@ public class StreamTest extends ActorBaseTest
                 .publish("data").join();
 
         // create a second stage from which the stream is going to be used
-        createStage();
+        final Stage stage2 = createStage();
         AsyncStream<String> test = AsyncStream.getStream(String.class, "test");
         BlockingQueue queue = new LinkedBlockingQueue<>();
         test.subscribe((msg,t) -> {
@@ -85,6 +85,8 @@ public class StreamTest extends ActorBaseTest
 
         // Stopping the first stage, the stream should migrate on the next post.
         stage1.stop().join();
+
+        stage2.bind();
 
         test.publish("hello2");
         assertEquals("hello2", queue.poll(5, TimeUnit.SECONDS));


### PR DESCRIPTION
Motivation:

When a node is shutting down other members of the cluster should be informed.

Modifications:

Broadcast NodeState.STOPPING on stage shutdown.
Fixed tests.

Result:

Correct node shutdown.