### PR TITLE
Observer method may be invoked from JGroups thread

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/ObserverEntry.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/ObserverEntry.java
@@ -42,7 +42,6 @@ public class ObserverEntry<T> implements LocalObjects.LocalObjectEntry<T>
 
     public ObserverEntry(final RemoteReference reference, final T object)
     {
-
         this.reference = reference;
         this.object = new WeakReference<>(object);
     }
@@ -62,7 +61,7 @@ public class ObserverEntry<T> implements LocalObjects.LocalObjectEntry<T>
     @Override
     public <R> Task<R> run(final TaskFunction<LocalObjects.LocalObjectEntry<T>, R> function)
     {
-        return function.apply(this);
+        return executionSerializer.offerJob(reference, () -> function.apply(ObserverEntry.this), 10000);
     }
 
     public void setExecutionSerializer(final MultiExecutionSerializer<Object> executionSerializer)


### PR DESCRIPTION
Motivation:

Blocking IO method invoked from observer may disrupt JGroups..

Modifications:

Execute observer method in execution thread.

Result:

Fixes #213.