### PR TITLE
Actually wait for servers

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
@@ -468,7 +468,7 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
                 }
                 if (logger.isDebugEnabled())
                 {
-                    logger.debug("No node available at the moment to place actor: {}.", interfaceClassName);
+                    logger.debug("No node available to activate actor: {}.", interfaceClassName);
                 }
                 waitForServers();
             }
@@ -510,19 +510,15 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
 
     private void waitForServers()
     {
-        // waits for servers
         synchronized (serverNodesUpdateMutex)
         {
-            if (serverNodes.size() == 0)
+            try
             {
-                try
-                {
-                    serverNodesUpdateMutex.wait(5);
-                }
-                catch (InterruptedException e)
-                {
-                    throw new UncheckedException(e);
-                }
+                serverNodesUpdateMutex.wait(2500);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
             }
         }
     }

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/reentrant/ReentrantTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/reentrant/ReentrantTest.java
@@ -58,8 +58,6 @@ public class ReentrantTest extends ActorBaseTest
         Task<Void> doSomething2(String goStr);
 
         Task<Void> doSomething3();
-
-        Task<Void> doSomething4();
     }
 
     public static class ReentrantActorImpl extends AbstractActor implements ReentrantActor
@@ -89,13 +87,6 @@ public class ReentrantTest extends ActorBaseTest
 
         @Override
         public Task<Void> doSomething3()
-        {
-            return Task.done();
-        }
-
-        @Override
-        @Reentrant
-        public Task<Void> doSomething4()
         {
             return Task.done();
         }
@@ -157,24 +148,6 @@ public class ReentrantTest extends ActorBaseTest
             }
             task1.get(5, TimeUnit.SECONDS);
             task2.get(5, TimeUnit.SECONDS);
-        }
-        finally
-        {
-            stage1.stop().join();
-        }
-    }
-
-    @Test(timeout = 10000)
-    public void testReentrantChain() throws Exception
-    {
-        Stage stage1 = createStage();
-        try
-        {
-            ReentrantActor actor = Actor.getReference(ReentrantActor.class, "1");
-            Task task1 = actor.doSomething4().thenCompose(x -> {
-                return actor.doSomething3();
-            });
-            task1.get(5, TimeUnit.SECONDS);
         }
         finally
         {


### PR DESCRIPTION
Motivation:

When Hosting selects a node and no server is available it should wait until another server joins the cluster or wait a few seconds to avoid burning CPU cycles.

Modifications:

Increase wait timeout from 5ms to 2500ms.

Result:

Fixes #217