### PR TITLE
Fix for live lock during Stage shutdown

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -176,7 +176,7 @@ public class Stage implements Startable, ActorRuntime
     private MultiExecutionSerializer<Object> executionSerializer;
     private ActorClassFinder finder;
     private LoggerExtension loggerExtension;
-    private NodeCapabilities.NodeState state;
+    private volatile NodeCapabilities.NodeState state;
 
     @Config("orbit.actors.concurrentDeactivations")
     private int concurrentDeactivations = 16;
@@ -757,7 +757,7 @@ public class Stage implements Startable, ActorRuntime
         logger.debug("Start stopping pipeline");
         CompletableFuture<Void> notified = new CompletableFuture<>();
         // await must not be used directly on actor call otherwise shutdown may continue in execution thread and cause livelock
-        hosting.notifyStateChange().whenCompleteAsync((r, e) -> notified.complete(null));
+        hosting.notifyStateChange().whenCompleteAsync((r, e) -> notified.complete(null), r -> new Thread(r).start());
         await(notified);
 
         logger.debug("Stopping actors");

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -1076,7 +1076,7 @@ public class Stage implements Startable, ActorRuntime
             @Override
             public void run()
             {
-                if (localActor.isDeactivated() || getState() != NodeCapabilities.NodeState.RUNNING)
+                if (localActor.isDeactivated())
                 {
                     cancel();
                     return;
@@ -1084,7 +1084,7 @@ public class Stage implements Startable, ActorRuntime
 
                 executionSerializer.offerJob(key,
                         () -> {
-                            if (localActor.isDeactivated() || getState() != NodeCapabilities.NodeState.RUNNING)
+                            if (localActor.isDeactivated())
                             {
                                 cancel();
                             }

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -118,6 +118,7 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinTask;
@@ -733,7 +734,7 @@ public class Stage implements Startable, ActorRuntime
         this.extensions.add(extension);
     }
 
-
+    @Override
     public Task<?> stop()
     {
         if (getState() != NodeCapabilities.NodeState.RUNNING)
@@ -753,28 +754,31 @@ public class Stage implements Startable, ActorRuntime
         // * wait pending tasks execution
         // * stop the network
 
-        logger.debug("start stopping pipeline");
-        await(hosting.notifyStateChange());
+        logger.debug("Start stopping pipeline");
+        CompletableFuture<Void> notified = new CompletableFuture<>();
+        // await must not be used directly on actor call otherwise shutdown may continue in execution thread and cause livelock
+        hosting.notifyStateChange().whenCompleteAsync((r, e) -> notified.complete(null));
+        await(notified);
 
-        logger.debug("stopping actors");
+        logger.debug("Stopping actors");
         await(stopActors());
-        logger.debug("stopping timers");
+        logger.debug("Stopping timers");
         await(stopTimers());
         do
         {
             InternalUtils.sleep(250);
         } while (executionSerializer.isBusy());
-        logger.debug("closing pipeline");
+        logger.debug("Closing pipeline");
         await(pipeline.close());
 
-        logger.debug("stopping execution serializer");
+        logger.debug("Stopping execution serializer");
         executionSerializer.shutdown();
 
-        logger.debug("stopping extensions");
+        logger.debug("Stopping extensions");
         await(stopExtensions());
 
         state = NodeCapabilities.NodeState.STOPPED;
-        logger.debug("stop done");
+        logger.debug("Stop done");
 
         return Task.done();
     }
@@ -1072,7 +1076,7 @@ public class Stage implements Startable, ActorRuntime
             @Override
             public void run()
             {
-                if (localActor.isDeactivated())
+                if (localActor.isDeactivated() || getState() != NodeCapabilities.NodeState.RUNNING)
                 {
                     cancel();
                     return;
@@ -1080,7 +1084,7 @@ public class Stage implements Startable, ActorRuntime
 
                 executionSerializer.offerJob(key,
                         () -> {
-                            if (localActor.isDeactivated())
+                            if (localActor.isDeactivated() || getState() != NodeCapabilities.NodeState.RUNNING)
                             {
                                 cancel();
                             }

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
@@ -340,8 +340,7 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
             }
             else
             {
-                final String interfaceClassName = interfaceClass.getName();
-                return selectNode(interfaceClassName, true);
+                return selectNode(interfaceClass.getName());
             }
         }
 
@@ -389,7 +388,7 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
             if (nodeAddress == null)
             {
                 // If not, select randomly
-                nodeAddress = await(selectNode(interfaceClass.getName(), true));
+                nodeAddress = await(selectNode(interfaceClass.getName()));
             }
 
             // Push our selection to the distributed cache (if possible)
@@ -439,7 +438,7 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
                 String.valueOf(actorReference.id));
     }
 
-    private Task<NodeAddress> selectNode(final String interfaceClassName, boolean allowToBlock)
+    private Task<NodeAddress> selectNode(final String interfaceClassName)
     {
         List<NodeInfo> potentialNodes;
         long start = System.currentTimeMillis();
@@ -462,7 +461,7 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
 
             if (potentialNodes.size() == 0)
             {
-                if (!allowToBlock)
+                if (stage.getState() != NodeCapabilities.NodeState.RUNNING)
                 {
                     return null;
                 }
@@ -514,7 +513,7 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
         {
             try
             {
-                serverNodesUpdateMutex.wait(2500);
+                serverNodesUpdateMutex.wait(1000);
             }
             catch (InterruptedException e)
             {


### PR DESCRIPTION
Motivation:

hosting.notifyStateChange() wrapped in await may cause executionSerializer to shut down within a task executed by executionSerializer.

Modifications:

Ensure Stage shutdown continues from calling thread.

Result:

Execution executor shuts down cleanly.