### PR TITLE
Feature/extensible message serializer

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Execution.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Execution.java
@@ -168,9 +168,9 @@ public class Execution extends AbstractExecution implements Startable
         }
         catch (Throwable exception)
         {
-            if (logger.isDebugEnabled())
+            if (logger.isErrorEnabled())
             {
-                logger.debug("Unknown application error. ", exception);
+                logger.error("Unknown application error. ", exception);
             }
             if (invocation.getCompletion() != null)
             {

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/JavaMessageSerializer.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/JavaMessageSerializer.java
@@ -28,7 +28,6 @@
 
 package cloud.orbit.actors.runtime;
 
-import cloud.orbit.actors.ActorObserver;
 import cloud.orbit.actors.cluster.NodeAddress;
 import cloud.orbit.actors.cluster.NodeAddressImpl;
 import cloud.orbit.actors.extensions.MessageSerializer;
@@ -36,11 +35,8 @@ import cloud.orbit.actors.extensions.MessageSerializer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInput;
-import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
-import java.io.ObjectOutputStream;
 import java.io.OutputStream;
-import java.io.Serializable;
 import java.util.Map;
 import java.util.UUID;
 
@@ -91,84 +87,15 @@ public class JavaMessageSerializer implements MessageSerializer
         out.writeObject(message.getPayload());
     }
 
-    private static class ReferenceReplacement implements Serializable
-    {
-        private static final long serialVersionUID = 1L;
-
-        Class<?> interfaceClass;
-        Object id;
-        NodeAddress address;
-    }
-
     protected ObjectOutput createObjectOutput(final BasicRuntime runtime, final OutputStream outputStream) throws IOException
     {
         // Message(messageId, type, reference, params) and Message(messageId, type, object)
-        return new ObjectOutputStream(outputStream)
-        {
-            {
-                enableReplaceObject(true);
-            }
-
-            @SuppressWarnings("rawtypes")
-            @Override
-            protected Object replaceObject(final Object obj) throws IOException
-            {
-                final RemoteReference reference;
-                if (!(obj instanceof RemoteReference))
-                {
-                    if (obj instanceof AbstractActor)
-                    {
-                        reference = ((AbstractActor) obj).reference;
-                    }
-                    else if (obj instanceof ActorObserver)
-                    {
-                        ActorObserver objectReference = runtime.registerObserver(null, (ActorObserver) obj);
-                        reference = (RemoteReference) objectReference;
-                    }
-                    else
-                    {
-                        return super.replaceObject(obj);
-                    }
-                }
-                else
-                {
-                    reference = (RemoteReference) obj;
-                }
-                ReferenceReplacement replacement = new ReferenceReplacement();
-                replacement.address = reference.address;
-                replacement.interfaceClass = reference._interfaceClass();
-                replacement.id = reference.id;
-                return replacement;
-            }
-        };
+        return new OrbitObjectOutputStream(outputStream, runtime);
     }
 
     protected ObjectInput createObjectInput(final BasicRuntime runtime, InputStream in) throws IOException
     {
-        return new ObjectInputStream(in)
-        {
-            {
-                enableResolveObject(true);
-            }
-
-            @SuppressWarnings({ "unchecked", "rawtypes" })
-            @Override
-            protected Object resolveObject(Object obj) throws IOException
-            {
-                if (obj instanceof ReferenceReplacement)
-                {
-                    ReferenceReplacement replacement = (ReferenceReplacement) obj;
-                    if (replacement.address != null)
-                    {
-                        return runtime.getRemoteObserverReference(replacement.address, (Class) replacement.interfaceClass, replacement.id);
-                    }
-                    return runtime.getReference((Class) replacement.interfaceClass, replacement.id);
-
-                }
-                return super.resolveObject(obj);
-            }
-        };
+        return new OrbitObjectInputStream(in, runtime);
     }
-
 
 }

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/OrbitObjectInputStream.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/OrbitObjectInputStream.java
@@ -1,0 +1,63 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.runtime;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+
+public class OrbitObjectInputStream extends ObjectInputStream
+{
+
+    private final BasicRuntime runtime;
+
+    public OrbitObjectInputStream(final InputStream in, final BasicRuntime runtime) throws IOException
+    {
+        super(in);
+        this.runtime = runtime;
+        enableResolveObject(true);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Override
+    protected Object resolveObject(Object obj) throws IOException
+    {
+        if (obj instanceof ReferenceReplacement)
+        {
+            final ReferenceReplacement replacement = (ReferenceReplacement) obj;
+            if (replacement.address != null)
+            {
+                return runtime.getRemoteObserverReference(replacement.address, (Class) replacement.interfaceClass, replacement.id);
+            }
+            return runtime.getReference((Class) replacement.interfaceClass, replacement.id);
+
+        }
+        return super.resolveObject(obj);
+    }
+}

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/OrbitObjectOutputStream.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/OrbitObjectOutputStream.java
@@ -71,7 +71,7 @@ public class OrbitObjectOutputStream extends ObjectOutputStream
         {
             reference = (RemoteReference) obj;
         }
-        ReferenceReplacement replacement = new ReferenceReplacement();
+        final ReferenceReplacement replacement = new ReferenceReplacement();
         replacement.address = reference.address;
         replacement.interfaceClass = reference._interfaceClass();
         replacement.id = reference.id;

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/OrbitObjectOutputStream.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/OrbitObjectOutputStream.java
@@ -1,0 +1,80 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.runtime;
+
+import cloud.orbit.actors.ActorObserver;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+
+public class OrbitObjectOutputStream extends ObjectOutputStream
+{
+
+    private final BasicRuntime runtime;
+
+    public OrbitObjectOutputStream(final OutputStream outputStream, final BasicRuntime runtime) throws IOException
+    {
+        super(outputStream);
+        this.runtime = runtime;
+        enableReplaceObject(true);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    protected Object replaceObject(final Object obj) throws IOException
+    {
+        final RemoteReference reference;
+        if (!(obj instanceof RemoteReference))
+        {
+            if (obj instanceof AbstractActor)
+            {
+                reference = ((AbstractActor) obj).reference;
+            }
+            else if (obj instanceof ActorObserver)
+            {
+                ActorObserver objectReference = runtime.registerObserver(null, (ActorObserver) obj);
+                reference = (RemoteReference) objectReference;
+            }
+            else
+            {
+                return super.replaceObject(obj);
+            }
+        }
+        else
+        {
+            reference = (RemoteReference) obj;
+        }
+        ReferenceReplacement replacement = new ReferenceReplacement();
+        replacement.address = reference.address;
+        replacement.interfaceClass = reference._interfaceClass();
+        replacement.id = reference.id;
+        return replacement;
+    }
+}

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/ReferenceReplacement.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/ReferenceReplacement.java
@@ -1,0 +1,42 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.runtime;
+
+import cloud.orbit.actors.cluster.NodeAddress;
+
+import java.io.Serializable;
+
+class ReferenceReplacement implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    Class<?> interfaceClass;
+    Object id;
+    NodeAddress address;
+}


### PR DESCRIPTION
We needed to extend the existing JavaMessageSerializer to customize the way the object replacement works.   I extracted some of the anonymous classes into public ones so that we could extend both the JavaMessageSerializer itself, and the InputStream and OutputStream as well.   The implementations are not changed. 