### PR TITLE
Failing test when attempting to run parallel/detached execution in an actor

### DIFF
--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/ParallelTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/ParallelTest.java
@@ -1,0 +1,56 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.test;
+
+import org.junit.Test;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.test.actors.Parallel1;
+import cloud.orbit.concurrent.Task;
+
+import java.util.UUID;
+
+public class ParallelTest extends ActorBaseTest
+{
+    @Test
+    public void testAttached()
+    {
+        this.createStage();
+        final Parallel1 actor = Actor.getReference(Parallel1.class, UUID.randomUUID().toString());
+        Task.allOf(actor.read(), actor.writeAttached()).join();
+    }
+
+    @Test
+    public void testDetached()
+    {
+        this.createStage();
+        final Parallel1 actor = Actor.getReference(Parallel1.class, UUID.randomUUID().toString());
+        Task.allOf(actor.read(), actor.writeDetached()).join();
+    }
+}

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/Parallel1.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/Parallel1.java
@@ -1,0 +1,41 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.test.actors;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.concurrent.Task;
+
+public interface Parallel1 extends Actor
+{
+    Task<Void> read();
+
+    Task<Void> writeAttached();
+
+    Task<Void> writeDetached();
+}

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/Parallel1Actor.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/Parallel1Actor.java
@@ -1,0 +1,75 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.test.actors;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.runtime.AbstractActor;
+import cloud.orbit.concurrent.Task;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class Parallel1Actor extends AbstractActor implements Parallel1
+{
+    private static final int NUM_ELEMENTS = 10_000_000;
+
+    private final List<Integer> list = IntStream.range(0, NUM_ELEMENTS).boxed().collect(Collectors.toList());
+
+    @Override
+    public Task<Void> read() {
+        this.list.forEach(i -> {
+        });
+        return Task.done();
+    }
+
+    @Override
+    public Task<Void> writeAttached() {
+        return this.otherActor().nothing().thenCompose(this::write);
+    }
+
+    @Override
+    public Task<Void> writeDetached() {
+        this.otherActor().nothing().thenCompose(this::write);
+        return Task.done();
+    }
+
+    private Parallel2 otherActor() {
+        return Actor.getReference(Parallel2.class, this.getIdentity());
+    }
+
+    private Task<Void> write() {
+        IntStream.range(0, NUM_ELEMENTS).forEach(i -> {
+            if (i % 10000 == 0) {
+                this.list.remove(i);
+            }
+        });
+        return Task.done();
+    }
+}

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/Parallel1State.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/Parallel1State.java
@@ -28,52 +28,15 @@
 
 package cloud.orbit.actors.test.actors;
 
-import cloud.orbit.actors.Actor;
-import cloud.orbit.actors.runtime.AbstractActor;
-import cloud.orbit.concurrent.Task;
+import java.util.ArrayList;
+import java.util.List;
 
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-public class Parallel1Actor extends AbstractActor<Parallel1State> implements Parallel1
+public class Parallel1State
 {
-    private static final int NUM_ELEMENTS = 10_000_000;
+    private final List<Integer> list = new ArrayList<>();
 
-    @Override
-    public Task<?> activateAsync()
+    public List<Integer> getList()
     {
-        state().getList().addAll(IntStream.range(0, NUM_ELEMENTS).boxed().collect(Collectors.toList()));
-        return super.activateAsync();
-    }
-
-    @Override
-    public Task<Void> read() {
-        state().getList().forEach(i -> {
-        });
-        return Task.done();
-    }
-
-    @Override
-    public Task<Void> writeAttached() {
-        return this.otherActor().nothing().thenCompose(this::write);
-    }
-
-    @Override
-    public Task<Void> writeDetached() {
-        this.otherActor().nothing().thenCompose(this::write);
-        return Task.done();
-    }
-
-    private Parallel2 otherActor() {
-        return Actor.getReference(Parallel2.class, this.getIdentity());
-    }
-
-    private Task<Void> write() {
-        IntStream.range(0, NUM_ELEMENTS).forEach(i -> {
-            if (i % 10000 == 0) {
-                state().getList().remove(i);
-            }
-        });
-        return Task.done();
+        return list;
     }
 }

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/Parallel2.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/Parallel2.java
@@ -1,0 +1,37 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.test.actors;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.concurrent.Task;
+
+public interface Parallel2 extends Actor
+{
+    Task<Void> nothing();
+}

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/Parallel2Actor.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/actors/Parallel2Actor.java
@@ -1,0 +1,41 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.test.actors;
+
+import cloud.orbit.actors.runtime.AbstractActor;
+import cloud.orbit.concurrent.Task;
+
+public class Parallel2Actor extends AbstractActor implements Parallel2
+{
+    @Override
+    public Task<Void> nothing()
+    {
+        return Task.done();
+    }
+}


### PR DESCRIPTION
My team is under the impression that the following should work without issue, and not break Orbit's guarantee that executions can't run in parallel on the same actor.

```
@Override
public Task<Void> foo() {
    someOtherActor.getId().thenAccept(id-> state().setId(id));
    return Task.done();
}
```

ie. invoking a method on another actor, and in a continuation function modifying the state of the current actor. Note that the above example does not chain and return the task, it's detached.

I added a test to prove that this works as we believed, but the test fails.

In the `ParallelTest` I added in this PR, `testDetached` causes a `ConcurrentModificationException`.

I'm wondering if we were correct in assuming that this is supported?

Thanks!

 