### PR TITLE
Fix broken select node implementation.

### DIFF
--- a/actors/core/src/main/java/cloud/orbit/actors/runtime/NodeInfo.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/runtime/NodeInfo.java
@@ -1,5 +1,6 @@
 package cloud.orbit.actors.runtime;
 
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import cloud.orbit.actors.cluster.NodeAddress;
@@ -13,6 +14,7 @@ public class NodeInfo
     NodeCapabilities nodeCapabilities;
     boolean cannotHostActors;
     final ConcurrentHashMap<String, Integer> canActivate = new ConcurrentHashMap<>();
+    final Set<String> canActivatePending = ConcurrentHashMap.newKeySet();
 
     public NodeInfo(final NodeAddress address)
     {


### PR DESCRIPTION
By running Alex's project I was able to reproduce a node lockup and it seems to point to an issue with the await state machine in the while loop which I have refactored out in this commit.

```java
    /*
     * Unable to fully structure code
     * Enabled aggressive block sorting
     * Enabled unnecessary exception pruning
     * Enabled aggressive exception aggregation
     * Lifted jumps to return sites
     */
    private static CompletableFuture async$selectNode(Hosting var0, String var1_1, long var2_2, List var4_3, List var5_4, NodeInfo var6_5, Integer var7_6, Task var8_7, int var9_9, Object var10_11) {
        switch (var9_9) {
            case 0: {
                start = System.currentTimeMillis();
lbl4: // 4 sources:
                if (System.currentTimeMillis() - start > this.timeToWaitForServersMillis) {
                    timeoutMessage = "Timeout waiting for a server capable of handling: " + (String)interfaceClassName;
                    this.logger.error(timeoutMessage);
                    return Task.fromException((Throwable)new UncheckedException(timeoutMessage));
                }
                currentServerNodes = this.serverNodes;
                potentialNodes = currentServerNodes.stream().filter((Predicate<NodeInfo>)LambdaMetafactory.metafactory(null, null, null, (Ljava/lang/Object;)Z, lambda$selectNode$9(java.lang.String cloud.orbit.actors.runtime.NodeInfo ), (Lcloud/orbit/actors/runtime/NodeInfo;)Z)((String)interfaceClassName)).collect(Collectors.toList());
                if (!potentialNodes.isEmpty()) ** GOTO lbl19
                if (this.stage.getState() != NodeCapabilities.NodeState.RUNNING) {
                    return Task.fromException((Throwable)new UncheckedException("No node found to activate " + (String)interfaceClassName));
                }
                if (this.logger.isDebugEnabled()) {
                    this.logger.debug("No node available to activate actor: {}.", (Object)interfaceClassName);
                }
                this.waitForServers();
                ** GOTO lbl4
lbl19: // 1 sources:
                nodeInfo = this.nodeSelector.select((String)interfaceClassName, this.getNodeAddress(), potentialNodes);
                canActivate = (Integer)nodeInfo.canActivate.get(interfaceClassName);
                if (canActivate != null) ** GOTO lbl40
                try {
                    v0 = nodeInfo.nodeCapabilities.canActivate((String)interfaceClassName);
                    if (!v0.toCompletableFuture().isDone()) {
                        var9_10 = v0;
                        return var9_10.exceptionally(Function.identity()).thenCompose((Function<Object, CompletableFuture>)LambdaMetafactory.metafactory(null, null, null, (Ljava/lang/Object;)Ljava/lang/Object;, async$selectNode(cloud.orbit.actors.runtime.Hosting java.lang.String long java.util.List java.util.List cloud.orbit.actors.runtime.NodeInfo java.lang.Integer cloud.orbit.concurrent.Task int java.lang.Object ), (Ljava/lang/Object;)Ljava/util/concurrent/CompletableFuture;)((Hosting)this, (String)interfaceClassName, (long)start, currentServerNodes, potentialNodes, (NodeInfo)nodeInfo, (Integer)canActivate, (Task)var9_10, (int)1)).toCompletableFuture();
                    }
                    ** GOTO lbl35
                }
                catch (Exception ex) {
                    this.logger.error("Error locating server for " + (String)interfaceClassName, (Throwable)ex);
                }
            }
            ** GOTO lbl4
            case 1: {
                v0 = ex;
lbl35: // 2 sources:
                if ((canActivate = (Integer)v0.toCompletableFuture().join()) == 2) {
                    nodeInfo.cannotHostActors = true;
                    nodeInfo.canActivate.put(interfaceClassName, 0);
                } else {
                    nodeInfo.canActivate.put(interfaceClassName, canActivate);
                }
lbl40: // 3 sources:
                if (canActivate != 1) ** GOTO lbl4
                return Task.fromValue((Object)nodeInfo.address);
            }
        }
        throw new IllegalArgumentException();
    }
```