### PR TITLE
Actor Deactivation Flow Changes

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -393,6 +393,7 @@ public class Stage implements Startable, ActorRuntime
             stage.setNodeName(nodeName);
             stage.setMode(mode);
             stage.setExecutionPoolSize(executionPoolSize);
+            stage.setLocalObjectsCleaner(localObjectsCleaner);
             stage.setTimer(timer);
             extensions.forEach(stage::addExtension);
             stage.setInvocationHandler(invocationHandler);

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -48,6 +48,7 @@ import cloud.orbit.actors.net.DefaultPipeline;
 import cloud.orbit.actors.net.Pipeline;
 import cloud.orbit.actors.runtime.AbstractActor;
 import cloud.orbit.actors.runtime.ActorBaseEntry;
+import cloud.orbit.actors.runtime.LocalObjectsCleaner;
 import cloud.orbit.actors.runtime.ActorEntry;
 import cloud.orbit.actors.runtime.ActorRuntime;
 import cloud.orbit.actors.runtime.ActorTaskContext;
@@ -204,6 +205,7 @@ public class Stage implements Startable, ActorRuntime
     private ExecutionObjectCloner objectCloner;
     private ExecutionObjectCloner messageLoopbackObjectCloner;
     private MessageSerializer messageSerializer;
+    private LocalObjectsCleaner localObjectsCleaner;
 
     private MultiExecutionSerializer<Object> executionSerializer;
     private ActorClassFinder finder;
@@ -239,6 +241,7 @@ public class Stage implements Startable, ActorRuntime
         private Messaging messaging;
         private InvocationHandler invocationHandler;
         private Execution execution;
+        private LocalObjectsCleaner localObjectsCleaner;
 
         private String basePackages;
         private String clusterName;
@@ -270,6 +273,12 @@ public class Stage implements Startable, ActorRuntime
         public Builder execution(Execution execution)
         {
             this.execution = execution;
+            return this;
+        }
+
+        public Builder localObjectsCleaner(LocalObjectsCleaner localObjectsCleaner)
+        {
+            this.localObjectsCleaner = localObjectsCleaner;
             return this;
         }
 
@@ -452,6 +461,15 @@ public class Stage implements Startable, ActorRuntime
         this.execution = execution;
     }
 
+    public void setLocalObjectsCleaner(final LocalObjectsCleaner localObjectsCleaner)
+    {
+        this.localObjectsCleaner = localObjectsCleaner;
+    }
+
+    public LocalObjectsCleaner getLocalObjectsCleaner() {
+        return localObjectsCleaner;
+    }
+
     public ExecutionObjectCloner getObjectCloner()
     {
         return objectCloner;
@@ -611,6 +629,10 @@ public class Stage implements Startable, ActorRuntime
         if (objectCloner == null)
         {
             objectCloner = new KryoCloner();
+        }
+        if(localObjectsCleaner == null)
+        {
+            localObjectsCleaner = new LocalObjectsCleaner(hosting, clock, executionPool, objects, defaultActorTTL, concurrentDeactivations, deactivationTimeoutMillis);
         }
 
         // create pipeline before waiting for ActorClassFinder as stop might be invoked before it is complete
@@ -832,96 +854,7 @@ public class Stage implements Startable, ActorRuntime
 
     private Task<Void> stopActors()
     {
-        // using negative age meaning all actors, regardless of age
-        await(cleanupActors(Long.MIN_VALUE));
-        await(cleanupActors(Long.MIN_VALUE)); // intentional second pass
-        return Task.done();
-    }
-
-    private Task<Void> cleanupObservers()
-    {
-        objects.stream()
-                .filter(e -> e.getValue() instanceof ObserverEntry && e.getValue().getObject() == null)
-                .forEach(e -> objects.remove(e.getKey(), e.getValue()));
-        return Task.done();
-    }
-
-    private Task<Void> cleanupActors(long maxAge)
-    {
-        // avoid sorting since lastAccess changes
-        // and O(N) is still smaller than O(N Log N)
-        final Iterator<Map.Entry<Object, LocalObjects.LocalObjectEntry>> iterator = objects.stream()
-                .filter(e -> e.getValue() instanceof ActorBaseEntry)
-                .iterator();
-
-        final List<Task<Void>> pending = new ArrayList<>();
-
-        // ensure that certain number of concurrent deactivations is happening at each moment
-        while (iterator.hasNext())
-        {
-            while (pending.size() < concurrentDeactivations && iterator.hasNext())
-            {
-
-                final Map.Entry<Object, LocalObjects.LocalObjectEntry> entryEntry = iterator.next();
-                final ActorBaseEntry<?> actorEntry = (ActorBaseEntry<?>) entryEntry.getValue();
-                if (actorEntry.isDeactivated())
-                {
-                    // this might happen if the deactivation is called outside this loop,
-                    // for instance by the stateless worker that owns the objects
-                    objects.remove(entryEntry.getKey(), entryEntry.getValue());
-                }
-
-                // Skip this actor if it is marked NeverDeactivate
-                if (maxAge != Long.MIN_VALUE && RemoteReference.getInterfaceClass(actorEntry.getRemoteReference()).isAnnotationPresent(NeverDeactivate.class)) {
-                    continue;
-                }
-
-                if (clock().millis() - actorEntry.getLastAccess() > maxAge)
-                {
-                    if (logger.isTraceEnabled())
-                    {
-                        logger.trace("deactivating {}", actorEntry.getRemoteReference());
-                    }
-                    pending.add(actorEntry.deactivate().failAfter(deactivationTimeoutMillis, TimeUnit.MILLISECONDS)
-                            .whenComplete((r, e) -> {
-                                // ensures removal
-                                if (e != null)
-                                {
-                                    // error occurred
-                                    if (logger.isErrorEnabled())
-                                    {
-                                        logger.error("Error during the deactivation of " + actorEntry.getRemoteReference(), e);
-                                    }
-                                    // forcefully setting the entry to deactivated
-                                    actorEntry.setDeactivated(true);
-                                }
-                                objects.remove(entryEntry.getKey(), entryEntry.getValue());
-                                if (entryEntry.getKey() == actorEntry.getRemoteReference())
-                                {
-                                    // removing non stateless actor from the distributed directory
-                                    getHosting().actorDeactivated(actorEntry.getRemoteReference());
-                                }
-                            }));
-                }
-            }
-            if (pending.size() > 0)
-            {
-                // await for at least one deactivation to complete
-                await(Task.anyOf(pending));
-                // remove all completed deactivations
-                for (int i = pending.size(); --i >= 0; )
-                {
-                    if (pending.get(i).isDone())
-                    {
-                        pending.remove(i);
-                    }
-                }
-            }
-        }
-        if (pending.size() > 0)
-        {
-            await(Task.allOf(pending));
-        }
+        await(localObjectsCleaner.shutdown());
         return Task.done();
     }
 
@@ -978,8 +911,7 @@ public class Stage implements Startable, ActorRuntime
     public Task cleanup()
     {
         await(execution.cleanup());
-        await(cleanupActors(defaultActorTTL));
-        await(cleanupObservers());
+        await(localObjectsCleaner.cleanup());
         await(messaging.cleanup());
 
         return Task.done();

--- a/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/ConcurrentExecutionQueue.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/ConcurrentExecutionQueue.java
@@ -1,0 +1,202 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.concurrent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cloud.orbit.actors.runtime.InternalUtils;
+import cloud.orbit.concurrent.Task;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.Supplier;
+
+/**
+ * Created by joeh on 2017-05-10.
+ */
+public class ConcurrentExecutionQueue implements Executor
+{
+    private static final Logger logger = LoggerFactory.getLogger(ConcurrentExecutionQueue.class);
+
+    private final ExecutorService executorService;
+    private final Integer concurrentExecutions;
+    private final Integer maxQueueSize;
+    private static final AtomicIntegerFieldUpdater<ConcurrentExecutionQueue> lockUpdater = AtomicIntegerFieldUpdater.newUpdater(ConcurrentExecutionQueue.class, "lock");
+    private static final AtomicIntegerFieldUpdater<ConcurrentExecutionQueue> queueSizeUpdater = AtomicIntegerFieldUpdater.newUpdater(ConcurrentExecutionQueue.class, "queueSize");
+    private static final AtomicIntegerFieldUpdater<ConcurrentExecutionQueue> inFlightUpdater = AtomicIntegerFieldUpdater.newUpdater(ConcurrentExecutionQueue.class, "inFlight");
+    private final ConcurrentLinkedQueue<Supplier<Task<?>>> queue = new ConcurrentLinkedQueue<>();
+
+    @SuppressWarnings("FieldCanBeLocal")
+    private volatile int lock = 0;
+    @SuppressWarnings("FieldCanBeLocal")
+    private volatile int queueSize = 0;
+    @SuppressWarnings("FieldCanBeLocal")
+    private volatile int inFlight = 0;
+
+    public ConcurrentExecutionQueue(final ExecutorService executorService, final int concurrentExecutions)
+    {
+        this(executorService, concurrentExecutions, 0);
+    }
+
+    public ConcurrentExecutionQueue(final ExecutorService executorService, final int concurrentExecutions, final int maxQueueSize)
+    {
+        this.executorService = executorService;
+        this.concurrentExecutions = concurrentExecutions;
+        this.maxQueueSize = maxQueueSize;
+    }
+
+    public <R> Task<R> execute(Supplier<Task<R>> taskSupplier)
+    {
+        final Task<R> completion = new Task<>();
+
+        if ((maxQueueSize > 0 && queueSize >= maxQueueSize) || !queue.add(() -> {
+            Task<R> source = InternalUtils.safeInvoke(taskSupplier);
+            InternalUtils.linkFutures(source, completion);
+            return source;
+        }))
+        {
+            throw new IllegalStateException(String.format("Queue full (%d > %d)", queue.size(), maxQueueSize));
+        }
+
+        queueSizeUpdater.incrementAndGet(this);
+
+        tryDrainQueue();
+
+        return completion;
+    }
+
+    public boolean hasBacklog() {
+        return queueSize > 0 || inFlight > 0;
+    }
+
+    private void tryDrainQueue()
+    {
+        while(!queue.isEmpty() && inFlight < concurrentExecutions) {
+            if (!lock())
+            {
+                // some other thread has the lock and it is now responsible for draining the queue.
+                return;
+            }
+
+            // while there is something in the queue
+            final Supplier<Task<?>> toRun = queue.poll();
+            if (toRun != null)
+            {
+                inFlightUpdater.incrementAndGet(this);
+                queueSizeUpdater.decrementAndGet(this);
+
+                try {
+                    final Task<?> task = new Task<>();
+                    executorService.execute(() -> {
+                        wrapExecution(toRun, task);
+                        if (task.isDone())
+                        {
+                            inFlightUpdater.decrementAndGet(this);
+                        } else {
+                            task.whenCompleteAsync(ConcurrentExecutionQueue.this::whenCompleteAsync, executorService);
+                        }
+                    });
+                } catch(Throwable error) {
+                    inFlightUpdater.decrementAndGet(this);
+                    try
+                    {
+                        logger.error("Error executing action", error);
+                    }
+                    catch (Throwable ex)
+                    {
+                        // just to be on the safe side... loggers can fail...
+                        ex.printStackTrace();
+                    }
+                }
+            }
+
+            unlock();
+        }
+    }
+
+    private <T> void whenCompleteAsync(T result, Throwable error)
+    {
+        inFlightUpdater.decrementAndGet(this);
+        tryDrainQueue();
+    }
+
+    @Override
+    public void execute(final Runnable command)
+    {
+        execute(() -> {
+            command.run();
+            return Task.done();
+        });
+    }
+
+    private void wrapExecution(final Supplier<Task<?>> toRun, final Task<?> taskFuture)
+    {
+        try
+        {
+            final Task<?> task = (Task) toRun.get();
+            if (task == null || task.isDone())
+            {
+                taskFuture.complete(null);
+            }
+            else
+            {
+                task.whenComplete((r, e) -> {
+                    if (e != null)
+                    {
+                        taskFuture.completeExceptionally(e);
+                    }
+                    else
+                    {
+                        taskFuture.complete(null);
+                    }
+                });
+            }
+        }
+        catch (Exception e)
+        {
+            taskFuture.completeExceptionally(e);
+        }
+    }
+
+    private void unlock()
+    {
+        if (!lockUpdater.compareAndSet(this, 1, 0))
+        {
+            logger.error("Unlocking without having the lock");
+        }
+    }
+
+    private boolean lock()
+    {
+        return lockUpdater.compareAndSet(this, 0, 1);
+    }
+}

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/LocalObjectsCleaner.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/LocalObjectsCleaner.java
@@ -51,14 +51,14 @@ public class LocalObjectsCleaner
 {
     private Logger logger = LoggerFactory.getLogger(LocalObjectsCleaner.class);
 
-    final LocalObjects localObjects;
-    final long defaultActorTTL;
-    final long deactivationTimeoutMillis;
-    final Clock clock;
-    final Hosting hosting;
-    final ConcurrentHashSet<ActorBaseEntry<?>> pendingDeactivations = new ConcurrentHashSet<>();
+    private final LocalObjects localObjects;
+    private final long defaultActorTTL;
+    private final long deactivationTimeoutMillis;
+    private final Clock clock;
+    private final Hosting hosting;
+    private final ConcurrentHashSet<ActorBaseEntry<?>> pendingDeactivations = new ConcurrentHashSet<>();
 
-    final ConcurrentExecutionQueue concurrentExecutionQueue;
+    private final ConcurrentExecutionQueue concurrentExecutionQueue;
 
 
     public LocalObjectsCleaner(final Hosting hosting, final Clock clock, final ExecutorService executor, final LocalObjects localObjects, final long defaultActorTTL, final int concurrentDeactivations, final long deactivationTimeoutMillis)
@@ -71,6 +71,7 @@ public class LocalObjectsCleaner
         this.concurrentExecutionQueue = new ConcurrentExecutionQueue(executor, concurrentDeactivations, 0);
     }
 
+    @SuppressWarnings("unchecked")
     public Task cleanup()
     {
         await(cleanupObservers());
@@ -78,6 +79,7 @@ public class LocalObjectsCleaner
         return Task.done();
     }
 
+    @SuppressWarnings("unchecked")
     public Task shutdown()
     {
         await(cleanupActors(true));
@@ -115,7 +117,6 @@ public class LocalObjectsCleaner
             shouldRemove = shouldRemove && !RemoteReference.getInterfaceClass(actorEntry.getRemoteReference()).isAnnotationPresent(NeverDeactivate.class);
             // Override if shutdownAll is true
             shouldRemove = shouldRemove || shutdownAll;
-
 
             if (shouldRemove)
             {

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/LocalObjectsCleaner.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/LocalObjectsCleaner.java
@@ -1,0 +1,160 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.runtime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cloud.orbit.actors.annotation.NeverDeactivate;
+import cloud.orbit.actors.concurrent.ConcurrentExecutionQueue;
+import cloud.orbit.concurrent.ConcurrentHashSet;
+import cloud.orbit.concurrent.Task;
+
+import java.time.Clock;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.ea.async.Async.await;
+
+/**
+ * Created by joeh on 2017-05-10.
+ */
+public class LocalObjectsCleaner
+{
+    private Logger logger = LoggerFactory.getLogger(LocalObjectsCleaner.class);
+
+    final LocalObjects localObjects;
+    final long defaultActorTTL;
+    final long deactivationTimeoutMillis;
+    final Clock clock;
+    final Hosting hosting;
+    final ConcurrentHashSet<ActorBaseEntry<?>> pendingDeactivations = new ConcurrentHashSet<>();
+
+    final ConcurrentExecutionQueue concurrentExecutionQueue;
+
+
+    public LocalObjectsCleaner(final Hosting hosting, final Clock clock, final ExecutorService executor, final LocalObjects localObjects, final long defaultActorTTL, final int concurrentDeactivations, final long deactivationTimeoutMillis)
+    {
+        this.hosting = hosting;
+        this.clock = clock;
+        this.localObjects = localObjects;
+        this.defaultActorTTL = defaultActorTTL;
+        this.deactivationTimeoutMillis = deactivationTimeoutMillis;
+        this.concurrentExecutionQueue = new ConcurrentExecutionQueue(executor, concurrentDeactivations, 0);
+    }
+
+    public Task cleanup()
+    {
+        await(cleanupObservers());
+        await(cleanupActors(false));
+        return Task.done();
+    }
+
+    public Task shutdown()
+    {
+        await(cleanupActors(true));
+        return Task.done();
+    }
+
+    public boolean hasBacklog()
+    {
+        return concurrentExecutionQueue.hasBacklog();
+    }
+
+    private Task cleanupActors(final boolean shutdownAll)
+    {
+        final Iterator<Map.Entry<Object, LocalObjects.LocalObjectEntry>> iterator = localObjects.stream()
+                .filter(e -> e.getValue() instanceof ActorBaseEntry)
+                .iterator();
+
+        while (iterator.hasNext())
+        {
+            final Map.Entry<Object, LocalObjects.LocalObjectEntry> entryEntry = iterator.next();
+            final ActorBaseEntry<?> actorEntry = (ActorBaseEntry<?>) entryEntry.getValue();
+
+            if (actorEntry.isDeactivated())
+            {
+                // this might happen if the deactivation is called outside this loop,
+                // for instance by the stateless worker that owns the objects
+                localObjects.remove(entryEntry.getKey(), entryEntry.getValue());
+                continue;
+            }
+
+            // Skip this actor if it is marked NeverDeactivate
+            if (!shutdownAll && RemoteReference.getInterfaceClass(actorEntry.getRemoteReference()).isAnnotationPresent(NeverDeactivate.class))
+            {
+                continue;
+            }
+
+            if (shutdownAll || clock.millis() - actorEntry.getLastAccess() > defaultActorTTL)
+            {
+                if (pendingDeactivations.add(actorEntry))
+                {
+                    concurrentExecutionQueue.execute(() ->
+                            actorEntry.deactivate().failAfter(deactivationTimeoutMillis, TimeUnit.MILLISECONDS)
+                                    .whenComplete((r, e) ->
+                                    {
+                                        // ensures removal
+                                        if (e != null)
+                                        {
+                                            // error occurred
+                                            if (logger.isErrorEnabled())
+                                            {
+                                                logger.error("Error during the deactivation of " + actorEntry.getRemoteReference(), e);
+                                            }
+                                            // forcefully setting the entry to deactivated
+                                            actorEntry.setDeactivated(true);
+                                        }
+
+                                        pendingDeactivations.remove(actorEntry);
+                                        localObjects.remove(entryEntry.getKey(), entryEntry.getValue());
+                                        if (entryEntry.getKey() == actorEntry.getRemoteReference())
+                                        {
+                                            // removing non stateless actor from the distributed directory
+                                            hosting.actorDeactivated(actorEntry.getRemoteReference());
+                                        }
+                                    }));
+                }
+            }
+        }
+
+        return Task.done();
+    }
+
+    private Task cleanupObservers()
+    {
+        localObjects.stream()
+                .filter(e -> e.getValue() instanceof ObserverEntry && e.getValue().getObject() == null)
+                .forEach(e -> localObjects.remove(e.getKey(), e.getValue()));
+        return Task.done();
+    }
+
+}

--- a/actors/test/actor-tests/src/main/java/cloud/orbit/actors/test/ActorBaseTest.java
+++ b/actors/test/actor-tests/src/main/java/cloud/orbit/actors/test/ActorBaseTest.java
@@ -493,7 +493,6 @@ public class ActorBaseTest
             isBusy = false;
             for(Stage stage : stages)
             {
-                System.out.println(stage);
                 if(stage.getLocalObjectsCleaner().hasBacklog())
                 {
                     isBusy = true;

--- a/actors/test/actor-tests/src/main/java/cloud/orbit/actors/test/ActorBaseTest.java
+++ b/actors/test/actor-tests/src/main/java/cloud/orbit/actors/test/ActorBaseTest.java
@@ -486,6 +486,24 @@ public class ActorBaseTest
 
     }
 
+    protected void waitForDeactivations() {
+        boolean isBusy;
+        do
+        {
+            isBusy = false;
+            for(Stage stage : stages)
+            {
+                System.out.println(stage);
+                if(stage.getLocalObjectsCleaner().hasBacklog())
+                {
+                    isBusy = true;
+                    break;
+                }
+
+            }
+        } while(isBusy);
+    }
+
 
     @After
     public void tearDown()

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/DeactivationTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/DeactivationTest.java
@@ -63,6 +63,7 @@ public class DeactivationTest extends ClientTest
         final UUID id = actor1.getUniqueActivationId().join();
         clock.incrementTime(20, TimeUnit.MINUTES);
         stage.cleanup().join();
+        waitForDeactivations();
         Assert.assertNotEquals(id, actor1.getUniqueActivationId().join());
         dumpMessages();
     }
@@ -78,6 +79,7 @@ public class DeactivationTest extends ClientTest
         final UUID id = actor1.getUniqueActivationId().join();
         clock.incrementTime(20, TimeUnit.MINUTES);
         stage.cleanup().join();
+        waitForDeactivations();
         Assert.assertNotEquals(id, actor1.getUniqueActivationId().join());
         dumpMessages();
     }
@@ -108,6 +110,7 @@ public class DeactivationTest extends ClientTest
         waitFor(() -> isIdle(stage));
         clock.incrementTime(20, TimeUnit.MINUTES);
         stage.cleanup().join();
+        waitForDeactivations();
         client.bind();
         set.add(actor1.getUniqueActivationId().join());
         assertEquals(2, set.size());
@@ -127,6 +130,7 @@ public class DeactivationTest extends ClientTest
         assertNotNull(actor1.sayHelloOnlyIfActivated().join());
         clock.incrementTimeMillis(TimeUnit.HOURS.toMillis(1));
         stage1.cleanup().join();
+        waitForDeactivations();
         eventuallyTrue(6000, () -> stage1.locateActor(RemoteReference.from(actor1), false).get() == null);
         assertNull(actor1.sayHelloOnlyIfActivated().join());
         dumpMessages();
@@ -175,8 +179,10 @@ public class DeactivationTest extends ClientTest
         loggerExtension.enableDebugFor(Stage.class);
         waitFor(() -> isIdle(stage1));
         stage1.cleanup().join();
+        waitForDeactivations();
         waitFor(() -> isIdle(stage1));
         stage1.cleanup().join();
+        waitForDeactivations();
 
 
         // do the shenanigans again
@@ -244,8 +250,10 @@ public class DeactivationTest extends ClientTest
         // this will collect all but one activation
         loggerExtension.enableDebugFor(Stage.class);
         stage1.cleanup().join();
+        waitForDeactivations();
         waitFor(() -> isIdle(stage1));
         stage1.cleanup().join();
+        waitForDeactivations();
 
 
         // do the shenanigans again

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/LifeCycleTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/LifeCycleTest.java
@@ -75,6 +75,8 @@ public class LifeCycleTest extends ActorBaseTest
         // touching the player to prevent it's deactivation;
         assertEquals(machEventCount, player.getMatchEventCount().get().intValue());
         stage.cleanup().join();
+        waitForDeactivations();
+
 
         // the match calls a player event on it's deactivation
         assertNotEquals(machEventCount, player.getMatchEventCount().get().intValue());

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/streams/StreamStatelessDeactivationTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/streams/StreamStatelessDeactivationTest.java
@@ -95,6 +95,7 @@ public class StreamStatelessDeactivationTest extends ActorBaseTest
         clock.incrementTime(20, TimeUnit.MINUTES);
         // actors get deactivated
         stage1.cleanup().join();
+        waitForDeactivations();
 
         // the actor has been deactivated so it won't receive this message
         test.publish("hello2").join();


### PR DESCRIPTION
This factors out deactivation from Stage and makes it fully asynchronous and lazy.
This is a major architecture change to how deactivation and shutdown works.

Rationale: 
* Makes it easier to reason about the deactivation flow during pulses.
  * A pulse cleanup just starts the deactivation tasks and does not wait on them.
  * Number of concurrent deactivations is handled at the threading level.
  * Ensures only one deactivation for an actor can be running at any one time.
    * This was a potential bug with the existing implementation.
* Allows us to handle shutdowns uniquely as this has always been an area of difficulty for us.
  * This first pass broadly does what the existing shutdown flow did.
* Makes it possible to extend the deactivation rules/system
  * I intend to follow up with a change to expose this via an extension
  * Plan to provide some default deactivation extensions such as culling LRU actors when short on memory.