### PR TITLE
Actor Deactivation Extensions

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorCountDeactivationExtension.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorCountDeactivationExtension.java
@@ -28,6 +28,9 @@
 
 package cloud.orbit.actors.extensions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import cloud.orbit.actors.runtime.ActorBaseEntry;
 
 import java.util.Collection;
@@ -39,6 +42,8 @@ import java.util.Set;
  */
 public class ActorCountDeactivationExtension implements ActorDeactivationExtension
 {
+    private static final Logger logger = LoggerFactory.getLogger(ActorCountDeactivationExtension.class);
+
     private final int maxActorCount;
     private final int targetActorCount;
 
@@ -51,11 +56,17 @@ public class ActorCountDeactivationExtension implements ActorDeactivationExtensi
     @Override
     public void cleanupActors(final Collection<ActorBaseEntry<?>> actorEntries, final Set<ActorBaseEntry<?>> toRemove)
     {
-        final Integer currentActorCount = actorEntries.size();
+        final int currentActorCount = actorEntries.size();
 
         if(currentActorCount > maxActorCount)
         {
             final int countToRemove = Math.abs(targetActorCount - currentActorCount);
+
+            if(logger.isWarnEnabled())
+            {
+                logger.warn("Stage has {} actors. The max actor count is set at {} with a target of {}. Attemping to deactivate {} actors to hit desired target."
+                        , currentActorCount, maxActorCount, targetActorCount, countToRemove);
+            }
 
             actorEntries.stream()
                     .sorted((Comparator.comparingLong(ActorBaseEntry::getLastAccess)))

--- a/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorCountDeactivationExtension.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorCountDeactivationExtension.java
@@ -42,20 +42,20 @@ public class ActorCountDeactivationExtension implements ActorDeactivationExtensi
     private final int maxActorCount;
     private final int targetActorCount;
 
-    public ActorCountDeactivationExtension(final int maxActorCount, final int removeActorCount)
+    public ActorCountDeactivationExtension(final int maxActorCount, final int targetActorCount)
     {
         this.maxActorCount = maxActorCount;
-        this.targetActorCount = removeActorCount;
+        this.targetActorCount = targetActorCount;
     }
 
     @Override
     public void cleanupActors(final Collection<ActorBaseEntry<?>> actorEntries, final Set<ActorBaseEntry<?>> toRemove)
     {
-        final Integer actorCount = actorEntries.size();
+        final Integer currentActorCount = actorEntries.size();
 
-        if(actorCount > maxActorCount)
+        if(currentActorCount > maxActorCount)
         {
-            final int countToRemove = Math.abs(targetActorCount - actorCount);
+            final int countToRemove = Math.abs(targetActorCount - currentActorCount);
 
             actorEntries.stream()
                     .sorted((Comparator.comparingLong(ActorBaseEntry::getLastAccess)))

--- a/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorCountDeactivationExtension.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorCountDeactivationExtension.java
@@ -1,0 +1,61 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions;
+
+import cloud.orbit.actors.runtime.ActorBaseEntry;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Set;
+
+/**
+ * Created by joeh on 2017-05-15.
+ */
+public class ActorCountDeactivationExtension implements ActorDeactivationExtension
+{
+    private final int maxActorCount;
+    private final int removeActorCount;
+
+    public ActorCountDeactivationExtension(final int maxActorCount, final int removeActorCount)
+    {
+        this.maxActorCount = maxActorCount;
+        this.removeActorCount = removeActorCount;
+    }
+
+    @Override
+    public void cleanupActors(final Collection<ActorBaseEntry<?>> actorEntries, final Set<ActorBaseEntry<?>> toRemove)
+    {
+        if(actorEntries.size() > maxActorCount) {
+            actorEntries.stream()
+                    .sorted((Comparator.comparingLong(ActorBaseEntry::getLastAccess)))
+                    .limit(removeActorCount)
+                    .forEach(toRemove::add);
+        }
+    }
+}

--- a/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorCountDeactivationExtension.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorCountDeactivationExtension.java
@@ -55,7 +55,7 @@ public class ActorCountDeactivationExtension implements ActorDeactivationExtensi
 
         if(actorCount > maxActorCount)
         {
-            final int countToRemove = (actorCount - maxActorCount) + targetActorCount;
+            final int countToRemove = Math.abs(targetActorCount - actorCount);
 
             actorEntries.stream()
                     .sorted((Comparator.comparingLong(ActorBaseEntry::getLastAccess)))

--- a/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorCountDeactivationExtension.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorCountDeactivationExtension.java
@@ -40,21 +40,26 @@ import java.util.Set;
 public class ActorCountDeactivationExtension implements ActorDeactivationExtension
 {
     private final int maxActorCount;
-    private final int removeActorCount;
+    private final int targetActorCount;
 
     public ActorCountDeactivationExtension(final int maxActorCount, final int removeActorCount)
     {
         this.maxActorCount = maxActorCount;
-        this.removeActorCount = removeActorCount;
+        this.targetActorCount = removeActorCount;
     }
 
     @Override
     public void cleanupActors(final Collection<ActorBaseEntry<?>> actorEntries, final Set<ActorBaseEntry<?>> toRemove)
     {
-        if(actorEntries.size() > maxActorCount) {
+        final Integer actorCount = actorEntries.size();
+
+        if(actorCount > maxActorCount)
+        {
+            final int countToRemove = (actorCount - maxActorCount) + targetActorCount;
+
             actorEntries.stream()
                     .sorted((Comparator.comparingLong(ActorBaseEntry::getLastAccess)))
-                    .limit(removeActorCount)
+                    .limit(countToRemove)
                     .forEach(toRemove::add);
         }
     }

--- a/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorMemoryDeactivationExtension.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorMemoryDeactivationExtension.java
@@ -41,9 +41,9 @@ import java.util.Set;
 /**
  * Created by joeh on 2017-05-15.
  */
-public class MemoryActorDeactivationExtension implements ActorDeactivationExtension
+public class ActorMemoryDeactivationExtension implements ActorDeactivationExtension
 {
-    private static final Logger logger = LoggerFactory.getLogger(MemoryActorDeactivationExtension.class);
+    private static final Logger logger = LoggerFactory.getLogger(ActorMemoryDeactivationExtension.class);
 
     private final int maxMemoryPct;
     private final int actorCullPct;
@@ -51,7 +51,7 @@ public class MemoryActorDeactivationExtension implements ActorDeactivationExtens
 
     private long lastCulling = 0;
 
-    public MemoryActorDeactivationExtension(final int maxMemoryPct, final int actorCullPct, final Duration maxFrequency)
+    public ActorMemoryDeactivationExtension(final int maxMemoryPct, final int actorCullPct, final Duration maxFrequency)
     {
         this.maxMemoryPct = maxMemoryPct;
         this.actorCullPct = actorCullPct;
@@ -63,11 +63,11 @@ public class MemoryActorDeactivationExtension implements ActorDeactivationExtens
     {
         final long currentTime = System.currentTimeMillis();
         final Runtime runtime = Runtime.getRuntime();
-        final long maxMem = runtime.maxMemory();
-        final long freeMem = runtime.freeMemory();
-        final long memoryPct = (freeMem / maxMem) * 100;
+        final float maxMem = runtime.maxMemory() / 1024 / 1024;
+        final float freeMem = runtime.freeMemory() / 1024 / 1024;
+        final int memoryPct  = (int) (((maxMem - freeMem) / maxMem) * 100.0f);
 
-        if(lastCulling + maxFrequency.toMillis() < currentTime)
+        //if(lastCulling + maxFrequency.toMillis() < currentTime)
         {
             if(memoryPct > maxMemoryPct) {
                 final int actorCount = actorEntries.size();

--- a/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorMemoryDeactivationExtension.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/extensions/ActorMemoryDeactivationExtension.java
@@ -67,7 +67,7 @@ public class ActorMemoryDeactivationExtension implements ActorDeactivationExtens
         final float freeMem = runtime.freeMemory() / 1024 / 1024;
         final int memoryPct  = (int) (((maxMem - freeMem) / maxMem) * 100.0f);
 
-        //if(lastCulling + maxFrequency.toMillis() < currentTime)
+        if(lastCulling + maxFrequency.toMillis() < currentTime)
         {
             if(memoryPct > maxMemoryPct) {
                 final int actorCount = actorEntries.size();

--- a/actors/runtime/src/main/java/cloud/orbit/actors/extensions/MemoryActorDeactivationExtension.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/extensions/MemoryActorDeactivationExtension.java
@@ -1,0 +1,91 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cloud.orbit.actors.runtime.ActorBaseEntry;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Set;
+
+/**
+ * Created by joeh on 2017-05-15.
+ */
+public class MemoryActorDeactivationExtension implements ActorDeactivationExtension
+{
+    private static final Logger logger = LoggerFactory.getLogger(MemoryActorDeactivationExtension.class);
+
+    private final int maxMemoryPct;
+    private final int actorCullPct;
+    private final Duration maxFrequency;
+
+    private long lastCulling = 0;
+
+    public MemoryActorDeactivationExtension(final int maxMemoryPct, final int actorCullPct, final Duration maxFrequency)
+    {
+        this.maxMemoryPct = maxMemoryPct;
+        this.actorCullPct = actorCullPct;
+        this.maxFrequency = maxFrequency;
+    }
+
+    @Override
+    public void cleanupActors(final Collection<ActorBaseEntry<?>> actorEntries, final Set<ActorBaseEntry<?>> toRemove)
+    {
+        final long currentTime = System.currentTimeMillis();
+        final Runtime runtime = Runtime.getRuntime();
+        final long maxMem = runtime.maxMemory();
+        final long freeMem = runtime.freeMemory();
+        final long memoryPct = (freeMem / maxMem) * 100;
+
+        if(lastCulling + maxFrequency.toMillis() < currentTime)
+        {
+            if(memoryPct > maxMemoryPct) {
+                final int actorCount = actorEntries.size();
+                final int cullCount = actorCount * (actorCullPct / 100);
+
+                if(logger.isWarnEnabled())
+                {
+                    logger.warn("JVM is reporting {}% memory usage. Max memory use is set at {}% with a cull setting of {}%. Attemping to deactivate {} of {} actors in accordance with cull options."
+                    , memoryPct, maxMemoryPct, actorCullPct, cullCount, actorCount);
+                }
+
+                actorEntries.stream()
+                        .sorted((Comparator.comparingLong(ActorBaseEntry::getLastAccess)))
+                        .limit(cullCount)
+                        .forEach(toRemove::add);
+
+                lastCulling = System.currentTimeMillis();
+            }
+        }
+    }
+}

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/ActorCountDeactivationTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/ActorCountDeactivationTest.java
@@ -41,8 +41,8 @@ import cloud.orbit.actors.test.actors.SomeActor;
  */
 public class ActorCountDeactivationTest extends ActorBaseTest
 {
-    final Integer maxActorCount = 50;
-    final Integer removeActorCount = 25;
+    private static final Integer maxActorCount = 50;
+    private static final Integer targetActorCount = 25;
 
     @Test
     public void testActorCountDeactivation() {
@@ -63,13 +63,13 @@ public class ActorCountDeactivationTest extends ActorBaseTest
         stage.cleanup().join();
         stage.cleanup().join();
 
-        Assert.assertTrue(stage.getLocalObjectCount() <= baseCount - removeActorCount);
+        Assert.assertTrue(stage.getLocalObjectCount() <= baseCount - targetActorCount);
 
     }
 
     @Override
     protected void installExtensions(final Stage stage)
     {
-        stage.addExtension(new ActorCountDeactivationExtension(maxActorCount, removeActorCount));
+        stage.addExtension(new ActorCountDeactivationExtension(maxActorCount, targetActorCount));
     }
 }

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/ActorCountDeactivationTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/ActorCountDeactivationTest.java
@@ -1,0 +1,75 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.Stage;
+import cloud.orbit.actors.extensions.ActorCountDeactivationExtension;
+import cloud.orbit.actors.test.actors.SomeActor;
+
+/**
+ * Created by joeh on 2017-05-15.
+ */
+public class ActorCountDeactivationTest extends ActorBaseTest
+{
+    final Integer maxActorCount = 50;
+    final Integer removeActorCount = 25;
+
+    @Test
+    public void testActorCountDeactivation() {
+        clock.stop();
+        Stage stage = createStage();
+
+        final Integer actorsToAdd = maxActorCount * 2;
+        long baseCount = stage.getLocalObjectCount();
+
+        for(Integer i = 0; i < actorsToAdd; ++i) {
+            Actor.getReference(SomeActor.class, i.toString()).sayHello("Hello").join();
+        }
+
+        Assert.assertTrue( stage.getLocalObjectCount() >= baseCount + actorsToAdd);
+
+        // Should trigger cleanup even without time passing
+        baseCount = stage.getLocalObjectCount();
+        stage.cleanup().join();
+        stage.cleanup().join();
+
+        Assert.assertTrue(stage.getLocalObjectCount() <= baseCount - removeActorCount);
+
+    }
+
+    @Override
+    protected void installExtensions(final Stage stage)
+    {
+        stage.addExtension(new ActorCountDeactivationExtension(maxActorCount, removeActorCount));
+    }
+}


### PR DESCRIPTION
This change introduces 2 new actor deactivation extensions:
* ActorCountDeactivationExtension - Allows you to specify deactivation rules triggered by the actor count.
* ActorMemoryDeactivationExtension - Allows you to specify deactivation rules based on reported JVM memory usage.