### PR TITLE
Actor construction extension

### DIFF
--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/ActorConstructionExtension.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/ActorConstructionExtension.java
@@ -28,8 +28,6 @@
 
 package cloud.orbit.actors.extensions;
 
-import cloud.orbit.exception.UncheckedException;
-
 /**
  * Created by joeh on 2017-05-29.
  */

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/ActorConstructionExtension.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/ActorConstructionExtension.java
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2016 Electronic Arts Inc.  All rights reserved.
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -28,57 +28,28 @@
 
 package cloud.orbit.actors.extensions;
 
-
-import cloud.orbit.actors.runtime.AbstractActor;
-import cloud.orbit.concurrent.Task;
 import cloud.orbit.exception.UncheckedException;
 
 /**
- * Listener the actor activation/deactivation process.
+ * Created by joeh on 2017-05-29.
  */
-public interface LifetimeExtension extends ActorExtension
+public interface ActorConstructionExtension extends ActorExtension
 {
     /**
-     * Called immediately before invoking the actors activation.
+     * Called to construct actor.
      *
-     * @param actor the actor object being activated
-     * @return a completion promise, the framework will wait if necessary.
+     * @param concreteClass concrete class of actor instance to construct
+     * @return instance of concreteClass
      */
-    default Task<?> preActivation(AbstractActor<?> actor)
+    default <T> T newInstance(Class<T> concreteClass)
     {
-        return Task.done();
-    }
-
-    /**
-     * Called immediately after invoking the actors activation.
-     *
-     * @param actor the actor object being activated
-     * @return a completion promise, the framework will wait if necessary.
-     */
-    default Task<?> postActivation(AbstractActor<?> actor)
-    {
-        return Task.done();
-    }
-
-    /**
-     * Called immediately before invoking the actors deactivation code.
-     *
-     * @param actor the actor object being deactivated
-     * @return a completion promise, the framework will wait if necessary.
-     */
-    default Task<?> preDeactivation(AbstractActor<?> actor)
-    {
-        return Task.done();
-    }
-
-    /**
-     * Called immediately after invoking the actors deactivation code.
-     *
-     * @param actor the actor object being deactivated
-     * @return a completion promise, the framework will wait if necessary.
-     */
-    default Task<?> postDeactivation(AbstractActor<?> actor)
-    {
-        return Task.done();
+        try
+        {
+            return concreteClass.newInstance();
+        }
+        catch (Exception ex)
+        {
+            throw new UncheckedException(ex);
+        }
     }
 }

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -43,6 +43,7 @@ import cloud.orbit.actors.cluster.NodeAddress;
 import cloud.orbit.actors.concurrent.MultiExecutionSerializer;
 import cloud.orbit.actors.concurrent.WaitFreeMultiExecutionSerializer;
 import cloud.orbit.actors.extensions.ActorClassFinder;
+import cloud.orbit.actors.extensions.ActorConstructionExtension;
 import cloud.orbit.actors.extensions.ActorDeactivationExtension;
 import cloud.orbit.actors.extensions.ActorExtension;
 import cloud.orbit.actors.extensions.DefaultLoggerExtension;
@@ -62,6 +63,7 @@ import cloud.orbit.actors.runtime.ActorTaskContext;
 import cloud.orbit.actors.runtime.AsyncStreamReference;
 import cloud.orbit.actors.runtime.BasicRuntime;
 import cloud.orbit.actors.runtime.ClusterHandler;
+import cloud.orbit.actors.runtime.DefaultActorConstructionExtension;
 import cloud.orbit.actors.runtime.DefaultDescriptorFactory;
 import cloud.orbit.actors.runtime.DefaultHandlers;
 import cloud.orbit.actors.runtime.DefaultInvocationHandler;
@@ -747,6 +749,17 @@ public class Stage implements Startable, ActorRuntime
         {
             lifetimeExtension = new DefaultLifetimeExtension();
             extensions.add(lifetimeExtension);
+        }
+
+        ActorConstructionExtension actorConstructionExtension = extensions.stream()
+                .filter(p -> p instanceof ActorConstructionExtension)
+                .map(p -> (ActorConstructionExtension) p)
+                .findFirst().orElse(null);
+
+        if (actorConstructionExtension == null)
+        {
+            actorConstructionExtension = new DefaultActorConstructionExtension();
+            extensions.add(actorConstructionExtension);
         }
 
         logger.debug("Starting messaging...");

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -743,24 +743,16 @@ public class Stage implements Startable, ActorRuntime
         LifetimeExtension lifetimeExtension = extensions.stream()
                 .filter(p -> p instanceof LifetimeExtension)
                 .map(p -> (LifetimeExtension) p)
-                .findFirst().orElse(null);
-
-        if (lifetimeExtension == null)
-        {
-            lifetimeExtension = new DefaultLifetimeExtension();
-            extensions.add(lifetimeExtension);
-        }
+                .findFirst()
+                .orElse(new DefaultLifetimeExtension());
+        extensions.add(lifetimeExtension);
 
         ActorConstructionExtension actorConstructionExtension = extensions.stream()
                 .filter(p -> p instanceof ActorConstructionExtension)
                 .map(p -> (ActorConstructionExtension) p)
-                .findFirst().orElse(null);
-
-        if (actorConstructionExtension == null)
-        {
-            actorConstructionExtension = new DefaultActorConstructionExtension();
-            extensions.add(actorConstructionExtension);
-        }
+                .findFirst()
+                .orElse(new DefaultActorConstructionExtension());
+        extensions.add(actorConstructionExtension);
 
         logger.debug("Starting messaging...");
         messaging.start();

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/ActorEntry.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/ActorEntry.java
@@ -28,6 +28,7 @@
 
 package cloud.orbit.actors.runtime;
 
+import cloud.orbit.actors.extensions.ActorConstructionExtension;
 import cloud.orbit.actors.extensions.LifetimeExtension;
 import cloud.orbit.actors.streams.AsyncStream;
 import cloud.orbit.actors.streams.StreamSubscriptionHandle;
@@ -107,7 +108,7 @@ public class ActorEntry<T extends AbstractActor> extends ActorBaseEntry<T>
                 return Task.fromValue(null);
             }
         }
-        final Object newInstance = runtime.getFirstExtension(LifetimeExtension.class).newInstance(concreteClass);
+        final Object newInstance = runtime.getFirstExtension(ActorConstructionExtension.class).newInstance(concreteClass);
         if (!AbstractActor.class.isInstance(newInstance))
         {
             throw new IllegalArgumentException(String.format("%s is not an actor class", concreteClass));

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/DefaultActorConstructionExtension.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/DefaultActorConstructionExtension.java
@@ -26,20 +26,26 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package cloud.orbit.actors.extensions;
+package cloud.orbit.actors.runtime;
 
+import cloud.orbit.actors.extensions.ActorConstructionExtension;
 import cloud.orbit.exception.UncheckedException;
 
 /**
  * Created by joeh on 2017-05-29.
  */
-public interface ActorConstructionExtension extends ActorExtension
+public class DefaultActorConstructionExtension implements ActorConstructionExtension
 {
-    /**
-     * Called to construct actor.
-     *
-     * @param concreteClass concrete class of actor instance to construct
-     * @return instance of concreteClass
-     */
-    <T> T newInstance(Class<T> concreteClass);
+    @Override
+    public <T> T newInstance(final Class<T> concreteClass)
+    {
+        try
+        {
+            return concreteClass.newInstance();
+        }
+        catch (Exception ex)
+        {
+            throw new UncheckedException(ex);
+        }
+    }
 }

--- a/actors/runtime/src/test/java/cloud/orbit/actors/extensions/test/ConstructionTest.java
+++ b/actors/runtime/src/test/java/cloud/orbit/actors/extensions/test/ConstructionTest.java
@@ -31,6 +31,7 @@ package cloud.orbit.actors.extensions.test;
 
 import cloud.orbit.actors.Actor;
 import cloud.orbit.actors.Stage;
+import cloud.orbit.actors.extensions.ActorConstructionExtension;
 import cloud.orbit.actors.extensions.LifetimeExtension;
 import cloud.orbit.actors.runtime.AbstractActor;
 import cloud.orbit.concurrent.Task;
@@ -85,7 +86,7 @@ public class ConstructionTest {
 
     }
 
-    public static class TestConstructionExtension implements LifetimeExtension {
+    public static class TestConstructionExtension implements ActorConstructionExtension {
 
         @Override
         public <T> T newInstance(final Class<T> concreteClass) {


### PR DESCRIPTION
**Overview**
This splits out the ability to override actor construction into it's own extension.

**Rationale**
It's reasonable to want more than one lifetime extension but that then means the actor construction that runs is effectively random depending on the ordering of those extensions.
With the new ActorConstructionExtension the expectation is that you only have one.