### PR TITLE
Allow starting stage after it has been previously stopped

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -577,7 +577,7 @@ public class Stage implements Startable, ActorRuntime
         logger.info("Starting Stage...");
         extensions = new ArrayList<>(extensions);
         startCalled = true;
-        if (state != null)
+        if (state != null && state != NodeCapabilities.NodeState.STOPPED)
         {
             throw new IllegalStateException("Can't start the stage at this state. " + this.toString());
         }
@@ -890,6 +890,7 @@ public class Stage implements Startable, ActorRuntime
         try
         {
             timer.cancel();
+            timer = null;
         }
         catch (final Throwable ex)
         {

--- a/actors/runtime/src/test/java/cloud/orbit/actors/StageTest.java
+++ b/actors/runtime/src/test/java/cloud/orbit/actors/StageTest.java
@@ -1,0 +1,64 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors;
+
+import org.junit.Test;
+
+import cloud.orbit.actors.annotation.NoIdentity;
+import cloud.orbit.actors.runtime.AbstractActor;
+import cloud.orbit.concurrent.Task;
+
+public class StageTest
+{
+    @Test
+    public void stageCanBeRestarted() throws Exception
+    {
+        Stage stage = new Stage();
+        stage.start().join();
+        Actor.getReference(MyActor.class).touch().join();
+        stage.stop().join();
+        stage.start().join();
+        Actor.getReference(MyActor.class).touch().join();
+    }
+
+    @NoIdentity
+    public interface MyActor extends Actor
+    {
+        Task<Void> touch();
+    }
+
+    public static class MyActorImpl extends AbstractActor implements MyActor
+    {
+        @Override
+        public Task<Void> touch()
+        {
+            return Task.done();
+        }
+    }
+}


### PR DESCRIPTION
While writing an integration test I noticed that I couldn't simply stop then start the Stage between tests; I had to kill and rebuild the Stage. Based on a comment on the `Startable` interface, I believe this is a bug.

> It must be possible to call start twice without errors.