### PR TITLE
InterceptableActorExtension

### DIFF
--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableActorClassFinder.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableActorClassFinder.java
@@ -1,0 +1,84 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptable;
+
+import cloud.orbit.actors.Actor;
+import cloud.orbit.actors.extensions.ActorClassFinder;
+import cloud.orbit.actors.extensions.interceptor.FinderInterceptor;
+import cloud.orbit.actors.extensions.interceptor.InterceptedValue;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class InterceptableActorClassFinder extends InterceptableActorExtension<FinderInterceptor, ActorClassFinder>
+        implements ActorClassFinder
+{
+    public InterceptableActorClassFinder(final ActorClassFinder extension,
+                                         final List<FinderInterceptor> interceptors)
+    {
+        super(extension, interceptors);
+    }
+
+    public InterceptableActorClassFinder(final ActorClassFinder extension)
+    {
+        super(extension);
+    }
+
+    @Override
+    public <T extends Actor> Class<? extends T> findActorImplementation(final Class<T> actorInterface)
+    {
+        if (!hasInterceptors())
+        {
+            return extension.findActorImplementation(actorInterface);
+        }
+        InterceptedValue<Class<T>> interceptedActorInterface = InterceptedValue.of(actorInterface);
+        intercept(interceptor -> interceptor.preFindActorImplementation(interceptedActorInterface));
+        InterceptedValue<Class<? extends T>> interceptedActorImplementation =
+                InterceptedValue.of(extension.findActorImplementation(interceptedActorInterface.get()));
+        intercept(interceptor ->
+                interceptor.postFindActorImplementation(interceptedActorInterface, interceptedActorImplementation));
+        return interceptedActorImplementation.get();
+    }
+
+    @Override
+    public <T extends Actor> Collection<Class<? extends T>> findActorInterfaces(final Predicate<Class<T>> predicate)
+    {
+        if (!hasInterceptors())
+        {
+            return extension.findActorInterfaces(predicate);
+        }
+        InterceptedValue<Predicate<Class<T>>> interceptedPredicate = InterceptedValue.of(predicate);
+        intercept(interceptor -> interceptor.preFindActorInterfaces(interceptedPredicate));
+        InterceptedValue<Collection<Class<? extends T>>> interceptedReturnValue =
+                InterceptedValue.of(extension.findActorInterfaces(interceptedPredicate.get()));
+        intercept(interceptor -> interceptor.postFindActorInterfaces(interceptedPredicate, interceptedReturnValue));
+        return interceptedReturnValue.get();
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableActorConstructionExtension.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableActorConstructionExtension.java
@@ -1,0 +1,66 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptable;
+
+import cloud.orbit.actors.extensions.ActorConstructionExtension;
+import cloud.orbit.actors.extensions.interceptor.ConstructionInterceptor;
+import cloud.orbit.actors.extensions.interceptor.InterceptedValue;
+
+import java.util.List;
+
+public class InterceptableActorConstructionExtension
+        extends InterceptableActorExtension<ConstructionInterceptor, ActorConstructionExtension>
+        implements ActorConstructionExtension
+{
+    public InterceptableActorConstructionExtension(final ActorConstructionExtension extension,
+                                                   final List<ConstructionInterceptor> interceptors)
+    {
+        super(extension, interceptors);
+    }
+
+    public InterceptableActorConstructionExtension(final ActorConstructionExtension extension)
+    {
+        super(extension);
+    }
+
+    @Override
+    public <T> T newInstance(final Class<T> concreteClass)
+    {
+        if (!hasInterceptors())
+        {
+            return extension.newInstance(concreteClass);
+        }
+        InterceptedValue<Class<T>> interceptedConcreteClass = InterceptedValue.of(concreteClass);
+        intercept(interceptor -> interceptor.preNewInstance(interceptedConcreteClass));
+        InterceptedValue<T> interceptedResult =
+                InterceptedValue.of(extension.newInstance(interceptedConcreteClass.get()));
+        intercept(interceptor -> interceptor.postNewInstance(interceptedConcreteClass, interceptedResult));
+        return interceptedResult.get();
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableActorExtension.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableActorExtension.java
@@ -1,0 +1,88 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptable;
+
+import cloud.orbit.actors.extensions.ActorExtension;
+import cloud.orbit.concurrent.Task;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static com.ea.async.Async.await;
+
+public abstract class InterceptableActorExtension<I, E extends ActorExtension> implements ActorExtension
+{
+    private final List<I> interceptors;
+    protected final E extension;
+
+    public InterceptableActorExtension(final E extension, final List<I> interceptors)
+    {
+        this.interceptors = interceptors;
+        this.extension = extension;
+    }
+
+    public InterceptableActorExtension(final E extension)
+    {
+        this(extension, new ArrayList<>());
+    }
+
+    public void addInterceptor(final I interceptor)
+    {
+        interceptors.add(interceptor);
+    }
+
+    public void addInterceptors(final List<I> interceptors)
+    {
+        this.interceptors.addAll(interceptors);
+    }
+
+    protected void intercept(final Consumer<I> function)
+    {
+        for (I interceptor : interceptors)
+        {
+            function.accept(interceptor);
+        }
+    }
+
+    protected Task<Void> interceptAsync(final Function<I, Task<?>> function)
+    {
+        for (I interceptor : interceptors)
+        {
+            await(function.apply(interceptor));
+        }
+        return Task.done();
+    }
+
+    protected boolean hasInterceptors()
+    {
+        return !interceptors.isEmpty();
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableMessageSerializer.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableMessageSerializer.java
@@ -1,0 +1,90 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptable;
+
+import cloud.orbit.actors.extensions.MessageSerializer;
+import cloud.orbit.actors.extensions.interceptor.InterceptedValue;
+import cloud.orbit.actors.extensions.interceptor.MessageInterceptor;
+import cloud.orbit.actors.runtime.BasicRuntime;
+import cloud.orbit.actors.runtime.Message;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+public class InterceptableMessageSerializer extends InterceptableActorExtension<MessageInterceptor, MessageSerializer>
+        implements MessageSerializer
+{
+    public InterceptableMessageSerializer(final MessageSerializer extension,
+                                          final List<MessageInterceptor> interceptors)
+    {
+        super(extension, interceptors);
+    }
+
+    public InterceptableMessageSerializer(final MessageSerializer extension)
+    {
+        super(extension);
+    }
+
+    @Override
+    public Message deserializeMessage(final BasicRuntime runtime, final InputStream inputStream) throws Exception
+    {
+        if (!hasInterceptors())
+        {
+            return extension.deserializeMessage(runtime, inputStream);
+        }
+        InterceptedValue<BasicRuntime> interceptedRuntime = InterceptedValue.of(runtime);
+        InterceptedValue<InputStream> interceptedInputStream = InterceptedValue.of(inputStream);
+        intercept(interceptor -> interceptor.preDeserializeMessage(interceptedRuntime, interceptedInputStream));
+        InterceptedValue<Message> interceptedReturnValue = InterceptedValue.of(
+                extension.deserializeMessage(interceptedRuntime.get(), interceptedInputStream.get()));
+        intercept(interceptor ->
+                interceptor.postDeserializeMessage(interceptedRuntime, interceptedInputStream, interceptedReturnValue));
+        return interceptedReturnValue.get();
+    }
+
+    @Override
+    public void serializeMessage(final BasicRuntime runtime, final OutputStream out, final Message message)
+            throws Exception
+    {
+        if (!hasInterceptors())
+        {
+            extension.serializeMessage(runtime, out, message);
+            return;
+        }
+        InterceptedValue<BasicRuntime> interceptedRuntime = InterceptedValue.of(runtime);
+        InterceptedValue<OutputStream> interceptedOut = InterceptedValue.of(out);
+        InterceptedValue<Message> interceptedMessage = InterceptedValue.of(message);
+        intercept(interceptor ->
+                interceptor.preSerializeMessage(interceptedRuntime, interceptedOut, interceptedMessage));
+        extension.serializeMessage(interceptedRuntime.get(), interceptedOut.get(), interceptedMessage.get());
+        intercept(interceptor ->
+                interceptor.postSerializeMessage(interceptedRuntime, interceptedOut, interceptedMessage));
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableNodeSelectorExtension.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableNodeSelectorExtension.java
@@ -1,0 +1,74 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptable;
+
+import cloud.orbit.actors.cluster.NodeAddress;
+import cloud.orbit.actors.extensions.NodeSelectorExtension;
+import cloud.orbit.actors.extensions.interceptor.InterceptedValue;
+import cloud.orbit.actors.extensions.interceptor.NodeSelectionInterceptor;
+import cloud.orbit.actors.runtime.NodeInfo;
+
+import java.util.List;
+
+public class InterceptableNodeSelectorExtension
+        extends InterceptableActorExtension<NodeSelectionInterceptor, NodeSelectorExtension>
+        implements NodeSelectorExtension
+{
+    public InterceptableNodeSelectorExtension(final NodeSelectorExtension extension,
+                                              final List<NodeSelectionInterceptor> interceptors)
+    {
+        super(extension, interceptors);
+    }
+
+    public InterceptableNodeSelectorExtension(final NodeSelectorExtension extension)
+    {
+        super(extension);
+    }
+
+    @Override
+    public NodeInfo select(final String interfaceClassName,
+                           final NodeAddress localAddress,
+                           final List<NodeInfo> potentialNodes)
+    {
+        if (!hasInterceptors())
+        {
+            return extension.select(interfaceClassName, localAddress, potentialNodes);
+        }
+        InterceptedValue<String> interceptedInterfaceClassName = InterceptedValue.of(interfaceClassName);
+        InterceptedValue<NodeAddress> interceptedLocalAddress = InterceptedValue.of(localAddress);
+        InterceptedValue<List<NodeInfo>> interceptedPotentialNodes = InterceptedValue.of(potentialNodes);
+        intercept(interceptor -> interceptor.preSelect(
+                interceptedInterfaceClassName, interceptedLocalAddress, interceptedPotentialNodes));
+        InterceptedValue<NodeInfo> interceptedReturnValue = InterceptedValue.of(extension.select(
+                interceptedInterfaceClassName.get(), interceptedLocalAddress.get(), interceptedPotentialNodes.get()));
+        intercept(interceptor -> interceptor.postSelect(interceptedInterfaceClassName, interceptedLocalAddress,
+                interceptedPotentialNodes, interceptedReturnValue));
+        return interceptedReturnValue.get();
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableStorageExtension.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableStorageExtension.java
@@ -1,0 +1,105 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptable;
+
+import cloud.orbit.actors.extensions.StorageExtension;
+import cloud.orbit.actors.extensions.interceptor.InterceptedValue;
+import cloud.orbit.actors.extensions.interceptor.StorageInterceptor;
+import cloud.orbit.actors.runtime.RemoteReference;
+import cloud.orbit.concurrent.Task;
+
+import java.util.List;
+
+import static com.ea.async.Async.await;
+
+public class InterceptableStorageExtension extends InterceptableActorExtension<StorageInterceptor, StorageExtension>
+        implements StorageExtension
+{
+    public InterceptableStorageExtension(final StorageExtension extension, final List<StorageInterceptor> interceptors)
+    {
+        super(extension, interceptors);
+    }
+
+    public InterceptableStorageExtension(final StorageExtension extension)
+    {
+        super(extension);
+    }
+
+    @Override
+    public String getName()
+    {
+        return extension.getName();
+    }
+
+    @Override
+    public Task<Void> clearState(final RemoteReference<?> reference, final Object state)
+    {
+        if (!hasInterceptors())
+        {
+            return extension.clearState(reference, state);
+        }
+        InterceptedValue<RemoteReference<?>> interceptedReference = InterceptedValue.of(reference);
+        InterceptedValue interceptedState = InterceptedValue.of(state);
+        await(interceptAsync(interceptor -> interceptor.preClearState(interceptedReference, interceptedState)));
+        await(extension.clearState(interceptedReference.get(), interceptedState.get()));
+        return interceptAsync(interceptor -> interceptor.postClearState(interceptedReference, interceptedState));
+    }
+
+    @Override
+    public Task<Boolean> readState(final RemoteReference<?> reference, final Object state)
+    {
+        if (!hasInterceptors())
+        {
+            return extension.readState(reference, state);
+        }
+        InterceptedValue<RemoteReference<?>> interceptedReference = InterceptedValue.of(reference);
+        InterceptedValue interceptedState = InterceptedValue.of(state);
+        await(interceptAsync(interceptor -> interceptor.preReadState(interceptedReference, interceptedState)));
+        InterceptedValue<Boolean> interceptedReturnValue =
+                InterceptedValue.of(await(extension.readState(reference, state)));
+        await(interceptAsync(interceptor ->
+                interceptor.postReadState(interceptedReference, interceptedReference, interceptedReturnValue)));
+        return Task.fromValue(interceptedReturnValue.get());
+    }
+
+    @Override
+    public Task<Void> writeState(final RemoteReference<?> reference, final Object state)
+    {
+        if (!hasInterceptors())
+        {
+            return extension.writeState(reference, state);
+        }
+        InterceptedValue<RemoteReference<?>> interceptedReference = InterceptedValue.of(reference);
+        InterceptedValue interceptedState = InterceptedValue.of(state);
+        await(interceptAsync(interceptor -> interceptor.preWriteState(interceptedReference, interceptedState)));
+        await(extension.writeState(reference, state));
+        await(interceptAsync(interceptor -> interceptor.postWriteState(interceptedReference, interceptedState)));
+        return Task.done();
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableStreamProvider.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptable/InterceptableStreamProvider.java
@@ -1,0 +1,73 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptable;
+
+import cloud.orbit.actors.extensions.StreamProvider;
+import cloud.orbit.actors.extensions.interceptor.InterceptedValue;
+import cloud.orbit.actors.extensions.interceptor.StreamInterceptor;
+import cloud.orbit.actors.streams.AsyncStream;
+
+import java.util.List;
+
+public class InterceptableStreamProvider extends InterceptableActorExtension<StreamInterceptor, StreamProvider>
+        implements StreamProvider
+{
+    public InterceptableStreamProvider(final StreamProvider extension, final List<StreamInterceptor> interceptors)
+    {
+        super(extension, interceptors);
+    }
+
+    public InterceptableStreamProvider(final StreamProvider extension)
+    {
+        super(extension);
+    }
+
+    @Override
+    public <T> AsyncStream<T> getStream(final Class<T> dataClass, final String id)
+    {
+        if (!hasInterceptors())
+        {
+            return extension.getStream(dataClass, id);
+        }
+        InterceptedValue<Class<T>> interceptedDataClass = InterceptedValue.of(dataClass);
+        InterceptedValue<String> interceptedId = InterceptedValue.of(id);
+        intercept(interceptor -> interceptor.preGetStream(interceptedDataClass, interceptedId));
+        InterceptedValue<AsyncStream<T>> interceptedReturnValue =
+                InterceptedValue.of(extension.getStream(interceptedDataClass.get(), interceptedId.get()));
+        intercept(interceptor ->
+                interceptor.postGetStream(interceptedDataClass, interceptedId, interceptedReturnValue));
+        return interceptedReturnValue.get();
+    }
+
+    @Override
+    public String getName()
+    {
+        return extension.getName();
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/ConstructionInterceptor.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/ConstructionInterceptor.java
@@ -1,0 +1,40 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptor;
+
+public interface ConstructionInterceptor
+{
+    default <T> void preNewInstance(InterceptedValue<Class<T>> concreteClass)
+    {
+    }
+
+    default <T> void postNewInstance(InterceptedValue<Class<T>> concreteClass, InterceptedValue<T> actor)
+    {
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/FinderInterceptor.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/FinderInterceptor.java
@@ -1,0 +1,53 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptor;
+
+import java.util.Collection;
+import java.util.function.Predicate;
+
+public interface FinderInterceptor
+{
+    default <T> void preFindActorImplementation(InterceptedValue<Class<T>> actorInterface)
+    {
+    }
+
+    default <T> void postFindActorImplementation(InterceptedValue<Class<T>> actorInterface,
+                                                 InterceptedValue<Class<? extends T>> actor)
+    {
+    }
+
+    default <T> void preFindActorInterfaces(InterceptedValue<Predicate<Class<T>>> predicate)
+    {
+    }
+
+    default <T> void postFindActorInterfaces(InterceptedValue<Predicate<Class<T>>> predicate,
+                                             InterceptedValue<Collection<Class<? extends T>>> actorInterfaces)
+    {
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/InterceptedValue.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/InterceptedValue.java
@@ -1,0 +1,57 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptor;
+
+/**
+ * Used to wrap variables that can be intercepted and potentially altered
+ */
+public class InterceptedValue<V>
+{
+    private V value;
+
+    private InterceptedValue(final V value)
+    {
+        this.value = value;
+    }
+
+    public static <V> InterceptedValue<V> of(V value)
+    {
+        return new InterceptedValue<>(value);
+    }
+
+    public V get()
+    {
+        return value;
+    }
+
+    public void set(final V value)
+    {
+        this.value = value;
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/MessageInterceptor.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/MessageInterceptor.java
@@ -1,0 +1,61 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptor;
+
+import cloud.orbit.actors.runtime.BasicRuntime;
+import cloud.orbit.actors.runtime.Message;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public interface MessageInterceptor
+{
+    default void preDeserializeMessage(InterceptedValue<BasicRuntime> runtime,
+                                       InterceptedValue<InputStream> inputStream)
+    {
+    }
+
+    default void postDeserializeMessage(InterceptedValue<BasicRuntime> runtime,
+                                        InterceptedValue<InputStream> inputStream,
+                                        InterceptedValue<Message> message)
+    {
+    }
+
+    default void preSerializeMessage(InterceptedValue<BasicRuntime> runtime,
+                                     InterceptedValue<OutputStream> out,
+                                     InterceptedValue<Message> message)
+    {
+    }
+
+    default void postSerializeMessage(InterceptedValue<BasicRuntime> runtime,
+                                      InterceptedValue<OutputStream> out,
+                                      InterceptedValue<Message> message)
+    {
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/NodeSelectionInterceptor.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/NodeSelectionInterceptor.java
@@ -1,0 +1,50 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptor;
+
+import cloud.orbit.actors.cluster.NodeAddress;
+import cloud.orbit.actors.runtime.NodeInfo;
+
+import java.util.List;
+
+public interface NodeSelectionInterceptor
+{
+    default void preSelect(InterceptedValue<String> interfaceClassName,
+                           InterceptedValue<NodeAddress> localAddress,
+                           InterceptedValue<List<NodeInfo>> potentialNodes)
+    {
+    }
+
+    default void postSelect(InterceptedValue<String> interfaceClassName,
+                            InterceptedValue<NodeAddress> localAddress,
+                            InterceptedValue<List<NodeInfo>> potentialNodes,
+                            InterceptedValue<NodeInfo> nodeInfo)
+    {
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/StorageInterceptor.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/StorageInterceptor.java
@@ -1,0 +1,66 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptor;
+
+import cloud.orbit.actors.runtime.RemoteReference;
+import cloud.orbit.concurrent.Task;
+
+public interface StorageInterceptor
+{
+    default Task<Void> preClearState(InterceptedValue<RemoteReference<?>> reference, InterceptedValue state)
+    {
+        return Task.done();
+    }
+
+    default Task<Void> postClearState(InterceptedValue<RemoteReference<?>> reference, InterceptedValue state)
+    {
+        return Task.done();
+    }
+
+    default Task<Void> preReadState(InterceptedValue<RemoteReference<?>> reference, InterceptedValue state)
+    {
+        return Task.done();
+    }
+
+    default Task<Void> postReadState(InterceptedValue<RemoteReference<?>> reference, InterceptedValue state,
+                                     InterceptedValue<Boolean> modified)
+    {
+        return Task.done();
+    }
+
+    default Task<Void> preWriteState(InterceptedValue<RemoteReference<?>> reference, InterceptedValue state)
+    {
+        return Task.done();
+    }
+
+    default Task<Void> postWriteState(InterceptedValue<RemoteReference<?>> reference, InterceptedValue state)
+    {
+        return Task.done();
+    }
+}

--- a/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/StreamInterceptor.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/extensions/interceptor/StreamInterceptor.java
@@ -1,0 +1,44 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.extensions.interceptor;
+
+import cloud.orbit.actors.streams.AsyncStream;
+
+public interface StreamInterceptor
+{
+    default <T> void preGetStream(InterceptedValue<Class<T>> dataClass, InterceptedValue<String> id)
+    {
+    }
+
+    default <T> void postGetStream(InterceptedValue<Class<T>> dataClass,
+                                   InterceptedValue<String> id,
+                                   InterceptedValue<AsyncStream<T>> stream)
+    {
+    }
+}


### PR DESCRIPTION
Adds the abstract `InterceptableActorExtension` class which decorates `ActorExtension` and allows interception of calls to its delegate ActorExtension.

Example:
```java
StorageExtension existingExtension = getStorageExtensionFromStage(stage);

InterceptableStorageExtension interceptableExtension = 
        new InterceptableStorageExtension(existingExtension);
interceptableExtension.addInterceptor(new TimerStorageInterceptor());

stage.getExtensions().remove(existingExtension);
stage.addExtension(interceptableExtension);
```
```java
class TimerStorageInterceptor implements StorageInterceptor {

    long timeStart;

    @Override
    public Task<Void> preWriteState(final InterceptedValue<RemoteReference<?>> reference,
                                    final InterceptedValue state) {
        timeStart = System.currentTimeMillis();
        return Task.done();
    }

    @Override
    public Task<Void> postWriteState(final InterceptedValue<RemoteReference<?>> reference,
                                     final InterceptedValue state)
    {
        long timeElapsed = System.currentTimeMillis() - timeStart;
        System.out.println("Time elapsed: " + timeElapsed);
        return Task.done();
    }
}
```

Since the `InterceptableActorExtension` is a decorator, it's identical to the inner extension from Stage's point of view. This feature enables authors to extend the functionality of existing extensions without knowing their implementations.

To be honest, I'm not confident this feature will be accepted, which is why I didn't write any JavaDoc or tests. There's a good argument that authors would more readily write their own custom wrapping classes for their specific use cases. So absolutely feel free to close this PR if you share that sentiment.