### PR TITLE
Use get before computeIfAbsent

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/DefaultInvocationHandler.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/DefaultInvocationHandler.java
@@ -52,7 +52,11 @@ public class DefaultInvocationHandler extends SimpleInvocationHandler
     protected Task<Object> doInvoke(final Stage runtime, final Invocation invocation, final LocalObjects.LocalObjectEntry entry, final LocalObjects.LocalObjectEntry target, final Method method, final Boolean reentrant, final ObjectInvoker invoker)
     {
         final long startTimeNanos = System.nanoTime();
-        final List<InvocationHandlerExtension> invocationHandlerExtensions = handlerExtensionCache.computeIfAbsent(runtime.runtimeIdentity(), s -> Collections.unmodifiableList(runtime.getAllExtensions(InvocationHandlerExtension.class)));
+        final List<InvocationHandlerExtension> extensions = handlerExtensionCache.get(runtime.runtimeIdentity());
+
+        final List<InvocationHandlerExtension> invocationHandlerExtensions = extensions == null ?
+                handlerExtensionCache.computeIfAbsent(runtime.runtimeIdentity(), s -> Collections.unmodifiableList(runtime.getAllExtensions(InvocationHandlerExtension.class))) :
+                extensions;
 
         // Before invoke actions
         Task<?> beforeInvokeChain = Task.done();

--- a/actors/test/benchmarks/src/main/java/cloud/orbit/actors/test/ConcurrentHashMapBenchmark.java
+++ b/actors/test/benchmarks/src/main/java/cloud/orbit/actors/test/ConcurrentHashMapBenchmark.java
@@ -1,0 +1,67 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.test;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ConcurrentHashMapBenchmark
+{
+    @State(Scope.Benchmark)
+    public static class ConcurrentHashMapState {
+
+        private final String key = UUID.randomUUID().toString();
+
+        private final ConcurrentHashMap<String, String> hashMap = new ConcurrentHashMap<>();
+
+    }
+
+    @Benchmark
+    @Threads(Threads.MAX)
+    public void concurrentHashMap_computeIfAbsent(final ConcurrentHashMapState state)
+    {
+        state.hashMap.computeIfAbsent(state.key, key -> UUID.randomUUID().toString());
+    }
+
+    @Benchmark
+    @Threads(Threads.MAX)
+    public void concurrentHashMap_getThenComputeIfAbsent(final ConcurrentHashMapState state)
+    {
+        final String value = state.hashMap.get(state.key);
+        if(value == null)
+        {
+            state.hashMap.computeIfAbsent(state.key, key -> UUID.randomUUID().toString());
+        }
+    }
+}


### PR DESCRIPTION
Noticed a lot of thread blocking when using `computeIfAbsent` on each invocation in a `ConcurrentHashMap`.  Calling `get` first, and only using `computeIfAbsent` if `get` returned `null ` cleared up many performance issues.