### PR TITLE
Always nullify actor on deactivation even if it fails so it can be GC…

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/ConcurrentExecutionQueue.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/ConcurrentExecutionQueue.java
@@ -118,19 +118,24 @@ public class ConcurrentExecutionQueue implements Executor
                         {
                             inFlightUpdater.decrementAndGet(this);
                             tryDrainQueue();
-                        } else {
+                        }
+                        else
+                        {
                             task.whenCompleteAsync(ConcurrentExecutionQueue.this::whenCompleteAsync, executorService);
                         }
                     });
-                } catch(Throwable error) {
+                }
+                catch (Throwable ex)
+                {
                     inFlightUpdater.decrementAndGet(this);
                     try
                     {
-                        logger.error("Error executing action", error);
+                        logger.error("Error executing action", ex);
                     }
-                    catch (Throwable ex)
+                    catch (Throwable ex2)
                     {
                         // just to be on the safe side... loggers can fail...
+                        ex2.printStackTrace();
                         ex.printStackTrace();
                     }
                 }

--- a/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeExecutionSerializer.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeExecutionSerializer.java
@@ -164,15 +164,16 @@ public class WaitFreeExecutionSerializer implements ExecutionSerializer, Executo
                         return;
                     }
                 }
-                catch (Throwable error)
+                catch (Throwable ex)
                 {
                     try
                     {
-                        logger.error("Error executing action", error);
+                        logger.error("Error executing action", ex);
                     }
-                    catch (Throwable ex)
+                    catch (Throwable ex2)
                     {
                         // just to be on the safe side... loggers can fail...
+                        ex2.printStackTrace();
                         ex.printStackTrace();
                     }
                 }


### PR DESCRIPTION
…'d (deactivation cannot run a second time so it doesn't make sense keeping the object in the actor entry).

Simplify DefaultLocalObjectsCleaner codeflow and fix possible race condition with invoking deactivate twice on an actor entry (not a problem but a waste of cycles).

Replace await with simple thenApply to cut down on bytecode of hot method locateAndActivateActor.