### PR TITLE
Response Cache Optimizations

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -88,7 +88,7 @@ import cloud.orbit.actors.runtime.RandomSelectorExtension;
 import cloud.orbit.actors.runtime.Registration;
 import cloud.orbit.actors.runtime.ReminderController;
 import cloud.orbit.actors.runtime.RemoteReference;
-import cloud.orbit.actors.runtime.ResponseCaching;
+import cloud.orbit.actors.runtime.DefaultResponseCachingExtension;
 import cloud.orbit.actors.runtime.SerializationHandler;
 import cloud.orbit.actors.runtime.StatelessActorEntry;
 import cloud.orbit.actors.streams.AsyncObserver;
@@ -715,7 +715,7 @@ public class Stage implements Startable, ActorRuntime
                 .findFirst()
                 .orElseGet(() ->
                 {
-                    final ResponseCaching responseCaching = new ResponseCaching();
+                    final DefaultResponseCachingExtension responseCaching = new DefaultResponseCachingExtension();
                     responseCaching.setObjectCloner(objectCloner);
                     responseCaching.setRuntime(this);
                     responseCaching.setMessageSerializer(messageSerializer);

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/DefaultResponseCachingExtension.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/DefaultResponseCachingExtension.java
@@ -106,7 +106,7 @@ public class DefaultResponseCachingExtension
     @Override
     public Task<?> get(Method method, Pair<Addressable, String> key)
     {
-        Cache<Pair<Addressable, String>, Task> cache = getIfPresent(method);
+        final Cache<Pair<Addressable, String>, Task> cache = getIfPresent(method);
         return cache != null ? cache.getIfPresent(key) : null;
     }
 
@@ -116,13 +116,13 @@ public class DefaultResponseCachingExtension
     @Override
     public void put(Method method, Pair<Addressable, String> key, Task<?> value)
     {
-        Cache<Pair<Addressable, String>, Task> cache = getCache(method);
+        final Cache<Pair<Addressable, String>, Task> cache = getCache(method);
         cache.put(key, value);
     }
 
     private Cache<Pair<Addressable, String>, Task> getIfPresent(Method method)
     {
-        CacheResponse cacheResponse = cacheResponseCache.getAnnotation(method);
+        final CacheResponse cacheResponse = cacheResponseCache.getAnnotation(method);
         if (cacheResponse == null)
         {
             throw new IllegalArgumentException("Passed non-CacheResponse method.");
@@ -137,7 +137,7 @@ public class DefaultResponseCachingExtension
      */
     private Cache<Pair<Addressable, String>, Task> getCache(Method method)
     {
-        CacheResponse cacheResponse = cacheResponseCache.getAnnotation(method);
+        final CacheResponse cacheResponse = cacheResponseCache.getAnnotation(method);
         if (cacheResponse == null)
         {
             throw new IllegalArgumentException("Passed non-CacheResponse method.");
@@ -161,8 +161,8 @@ public class DefaultResponseCachingExtension
     @Override
     public Task<Void> flush(Actor actor)
     {
-        RemoteReference actorReference = (RemoteReference) actor;
-        Class interfaceClass = RemoteReference.getInterfaceClass(actorReference);
+        final RemoteReference actorReference = (RemoteReference) actor;
+        final Class interfaceClass = RemoteReference.getInterfaceClass(actorReference);
 
         masterCache.asMap().entrySet().forEach(entry -> {
             if (interfaceClass.equals(entry.getKey().getDeclaringClass()))
@@ -186,8 +186,8 @@ public class DefaultResponseCachingExtension
 
     private Task<?> cacheResponseInvoke(HandlerContext ctx, Invocation invocation)
     {
-        String parameterHash = generateParameterHash(invocation.getParams());
-        Pair<Addressable, String> key = Pair.of(invocation.getToReference(), parameterHash);
+        final String parameterHash = generateParameterHash(invocation.getParams());
+        final Pair<Addressable, String> key = Pair.of(invocation.getToReference(), parameterHash);
 
         final Method method = invocation.getMethod();
         Task<?> cached = get(method, key);
@@ -216,7 +216,7 @@ public class DefaultResponseCachingExtension
         try
         {
             final MessageDigest md = messageDigest.newDigest();
-            DigestOutputStream d = new DigestOutputStream(new NullOutputStream(), md);
+            final DigestOutputStream d = new DigestOutputStream(new NullOutputStream(), md);
             messageSerializer.serializeMessage(runtime, d, new Message().withPayload(params));
             d.close();
             return String.format("%032X", new BigInteger(1, md.digest()));

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/CacheResponseCloneTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/CacheResponseCloneTest.java
@@ -31,7 +31,7 @@ package cloud.orbit.actors.test;
 import cloud.orbit.actors.Actor;
 import cloud.orbit.actors.Stage;
 import cloud.orbit.actors.runtime.KryoSerializer;
-import cloud.orbit.actors.runtime.ResponseCaching;
+import cloud.orbit.actors.runtime.DefaultResponseCachingExtension;
 import cloud.orbit.actors.runtime.NodeCapabilities;
 import cloud.orbit.actors.cloner.ExecutionObjectCloner;
 import cloud.orbit.actors.cloner.JavaSerializationCloner;
@@ -167,7 +167,7 @@ public class CacheResponseCloneTest extends ActorBaseTest
     @Before
     public void initializeCacheManager()
     {
-        ResponseCaching.setClock(null);
+        DefaultResponseCachingExtension.setClock(null);
     }
 
     @After

--- a/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/CacheResponseTest.java
+++ b/actors/test/actor-tests/src/test/java/cloud/orbit/actors/test/CacheResponseTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import cloud.orbit.actors.Actor;
 import cloud.orbit.actors.Stage;
 import cloud.orbit.actors.runtime.NodeCapabilities;
-import cloud.orbit.actors.runtime.ResponseCaching;
+import cloud.orbit.actors.runtime.DefaultResponseCachingExtension;
 import cloud.orbit.actors.test.actors.CacheResponse;
 import cloud.orbit.actors.test.actors.CacheResponseActor;
 import cloud.orbit.exception.UncheckedException;
@@ -62,7 +62,7 @@ public class CacheResponseTest extends ActorBaseTest
     @Test
     public void testCacheDuration()
     {
-        ResponseCaching.setClock(clock);
+        DefaultResponseCachingExtension.setClock(clock);
 
         CacheResponse actor = Actor.getReference(CacheResponse.class, UUID.randomUUID().toString());
 
@@ -126,7 +126,7 @@ public class CacheResponseTest extends ActorBaseTest
     @Test(timeout = 10_000L)
     public void testCacheFlush()
     {
-        ResponseCaching.setClock(clock);
+        DefaultResponseCachingExtension.setClock(clock);
 
         CacheResponse actor = Actor.getReference(CacheResponse.class, UUID.randomUUID().toString());
 
@@ -202,8 +202,8 @@ public class CacheResponseTest extends ActorBaseTest
     @Before
     public void initializeCacheManager()
     {
-        ResponseCaching.setCacheExecutor(Runnable::run);
-        ResponseCaching.setClock(null);
+        DefaultResponseCachingExtension.setCacheExecutor(Runnable::run);
+        DefaultResponseCachingExtension.setClock(null);
     }
 
     @After

--- a/commons/src/main/java/cloud/orbit/concurrent/MessageDigestFactory.java
+++ b/commons/src/main/java/cloud/orbit/concurrent/MessageDigestFactory.java
@@ -1,0 +1,91 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.concurrent;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Created by joeh on 2017-06-27.
+ */
+public class MessageDigestFactory
+{
+    private final String algorithm;
+    private final MessageDigest digestPrototype;
+    private final Boolean supportsClone;
+
+    public MessageDigestFactory(final String algorithm)
+    {
+        this.algorithm = algorithm;
+        this.digestPrototype = createJDKDigest(algorithm);
+        this.supportsClone = supportsCloning(digestPrototype);
+    }
+
+    private static boolean supportsCloning(MessageDigest messageDigest)
+    {
+        try
+        {
+            messageDigest.clone();
+            return true;
+        }
+        catch (CloneNotSupportedException e)
+        {
+            return false;
+        }
+    }
+
+    public MessageDigest newDigest()
+    {
+        if(supportsClone)
+        {
+            try
+            {
+                return (MessageDigest) digestPrototype.clone();
+            }
+            catch(CloneNotSupportedException e)
+            {
+                // Eat it and fall through
+            }
+        }
+
+        return createJDKDigest(algorithm);
+    }
+
+    private static MessageDigest createJDKDigest(final String algorithm)
+    {
+        try
+        {
+            return MessageDigest.getInstance(algorithm);
+        }
+        catch(NoSuchAlgorithmException ex)
+        {
+            throw new IllegalArgumentException(ex);
+        }
+    }
+}

--- a/commons/src/main/java/cloud/orbit/concurrent/MessageDigestFactory.java
+++ b/commons/src/main/java/cloud/orbit/concurrent/MessageDigestFactory.java
@@ -38,26 +38,13 @@ public class MessageDigestFactory
 {
     private final String algorithm;
     private final MessageDigest digestPrototype;
-    private final Boolean supportsClone;
+    private final boolean supportsClone;
 
     public MessageDigestFactory(final String algorithm)
     {
         this.algorithm = algorithm;
         this.digestPrototype = createJDKDigest(algorithm);
         this.supportsClone = supportsCloning(digestPrototype);
-    }
-
-    private static boolean supportsCloning(MessageDigest messageDigest)
-    {
-        try
-        {
-            messageDigest.clone();
-            return true;
-        }
-        catch (CloneNotSupportedException e)
-        {
-            return false;
-        }
     }
 
     public MessageDigest newDigest()
@@ -75,6 +62,19 @@ public class MessageDigestFactory
         }
 
         return createJDKDigest(algorithm);
+    }
+
+    private static boolean supportsCloning(MessageDigest messageDigest)
+    {
+        try
+        {
+            messageDigest.clone();
+            return true;
+        }
+        catch (CloneNotSupportedException e)
+        {
+            return false;
+        }
     }
 
     private static MessageDigest createJDKDigest(final String algorithm)


### PR DESCRIPTION
This resolves an issue discovered by @ceckhardt's team which causes thread contention in the Response Cache system. 
This is caused by locking internally in the JDK when creating a new message digest. It appears this is a known issue and has been worked around in other projects such as Guava and the recommendation is to clone the digest.