### PR TITLE
Make Kryo default message serializer

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -27,6 +27,9 @@
           </value>
         </option>
         <option name="JD_P_AT_EMPTY_LINES" value="false" />
+        <MarkdownNavigatorCodeStyleSettings>
+          <option name="RIGHT_MARGIN" value="72" />
+        </MarkdownNavigatorCodeStyleSettings>
         <XML>
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -711,7 +711,7 @@ public class Stage implements Startable, ActorRuntime
         }
         if (messageSerializer == null)
         {
-            messageSerializer = new JavaMessageSerializer();
+            messageSerializer = new KryoSerializer();
         }
         if (clusterPeer == null)
         {

--- a/actors/test/actor-tests/src/main/java/cloud/orbit/actors/test/ActorBaseTest.java
+++ b/actors/test/actor-tests/src/main/java/cloud/orbit/actors/test/ActorBaseTest.java
@@ -52,6 +52,7 @@ import cloud.orbit.actors.runtime.AbstractExecution;
 import cloud.orbit.actors.runtime.ActorFactoryGenerator;
 import cloud.orbit.actors.runtime.ActorTaskContext;
 import cloud.orbit.actors.runtime.Execution;
+import cloud.orbit.actors.runtime.JavaMessageSerializer;
 import cloud.orbit.actors.runtime.KryoSerializer;
 import cloud.orbit.actors.runtime.NodeCapabilities;
 import cloud.orbit.actors.server.ServerPeer;
@@ -282,6 +283,7 @@ public class ActorBaseTest
                 .clusterName(clusterName)
                 .clusterPeer(new FakeClusterPeer())
                 .extensions(lifetimeExtension)
+                .messageSerializer(new JavaMessageSerializer())
                 .build();
 
         stages.add(client);
@@ -319,7 +321,8 @@ public class ActorBaseTest
                 .objectCloner(getExecutionObjectCloner())
                 .clock(clock)
                 .clusterName(clusterName)
-                .clusterPeer(new FakeClusterPeer());
+                .clusterPeer(new FakeClusterPeer())
+                .messageSerializer(new JavaMessageSerializer());
 
         customizer.accept(builder);
 


### PR DESCRIPTION
This change makes Kryo the default message serializer in place of the Java message serializer.
Throughput for the Kryo serializer is on average 5x the Java message serializer. 

This is in a large part due to the optimization work @johnou has done around kryo. There are a few cases where the Kryo serializer is less flexible but the performance gain now seems worth the tradeoff. As such, some projects may need to switch back to the Java serializer or make some changes to their DTOs.

```
Kryo: 636254.682 ops/s
Java: 126572.244 ops/s
```