### PR TITLE
Actor Time to Live Override Annotation

### DIFF
--- a/actors/core/src/main/java/cloud/orbit/actors/annotation/TimeToLive.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/annotation/TimeToLive.java
@@ -34,6 +34,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Defines a custom time to live for the given actor that will be used instead of the
+ * configured <code>defaultActorTTL</code>.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface TimeToLive

--- a/actors/core/src/main/java/cloud/orbit/actors/annotation/TimeToLive.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/annotation/TimeToLive.java
@@ -1,0 +1,43 @@
+/*
+ Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface TimeToLive
+{
+    long value();
+    TimeUnit timeUnit() default TimeUnit.MILLISECONDS;
+}

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/DefaultLocalObjectsCleaner.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/DefaultLocalObjectsCleaner.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import cloud.orbit.actors.annotation.NeverDeactivate;
+import cloud.orbit.actors.annotation.TimeToLive;
 import cloud.orbit.actors.concurrent.ConcurrentExecutionQueue;
 import cloud.orbit.actors.extensions.ActorDeactivationExtension;
 import cloud.orbit.concurrent.Task;
@@ -166,16 +167,39 @@ public class DefaultLocalObjectsCleaner implements LocalObjectsCleaner
 
     private boolean shouldRemove(final ActorBaseEntry<?> actorEntry, final Set<ActorBaseEntry<?>> toRemove)
     {
+        final Class<?> interfaceClass = RemoteReference.getInterfaceClass(actorEntry.getRemoteReference())
         // Make sure it isn't tagged NeverDeactivate
-        if (RemoteReference.getInterfaceClass(actorEntry.getRemoteReference()).isAnnotationPresent(NeverDeactivate.class))
+        if (interfaceClass.isAnnotationPresent(NeverDeactivate.class))
         {
             return false;
         }
-        // Check for timeout
-        boolean shouldRemove = clock.millis() - actorEntry.getLastAccess() > defaultActorTTL;
+
+        // Check for ttl override
+        if(interfaceClass.isAnnotationPresent(TimeToLive.class))
+        {
+            final TimeToLive customTtl = interfaceClass.getAnnotation(TimeToLive.class);
+            final long customTtlMilliseconds = customTtl.timeUnit().toMillis(customTtl.value());
+            if(clock.millis() - actorEntry.getLastAccess() > customTtlMilliseconds)
+            {
+                return true;
+            }
+        } 
+        else
+            {
+            // Check against default
+            if(clock.millis() - actorEntry.getLastAccess() > defaultActorTTL)
+            {
+                return true;
+            }
+        }
+
+
         // Check if extension wanted to remove it
-        shouldRemove = shouldRemove || toRemove.contains(actorEntry);
-        return shouldRemove;
+        if(toRemove.contains(actorEntry)) {
+            return true;
+        }
+
+        return false;
     }
 
     private Task cleanupObservers()

--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/DefaultLocalObjectsCleaner.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/DefaultLocalObjectsCleaner.java
@@ -167,7 +167,7 @@ public class DefaultLocalObjectsCleaner implements LocalObjectsCleaner
 
     private boolean shouldRemove(final ActorBaseEntry<?> actorEntry, final Set<ActorBaseEntry<?>> toRemove)
     {
-        final Class<?> interfaceClass = RemoteReference.getInterfaceClass(actorEntry.getRemoteReference())
+        final Class<?> interfaceClass = RemoteReference.getInterfaceClass(actorEntry.getRemoteReference());
         // Make sure it isn't tagged NeverDeactivate
         if (interfaceClass.isAnnotationPresent(NeverDeactivate.class))
         {
@@ -183,7 +183,7 @@ public class DefaultLocalObjectsCleaner implements LocalObjectsCleaner
             {
                 return true;
             }
-        } 
+        }
         else
             {
             // Check against default


### PR DESCRIPTION
This change allows Orbit users to override the time to live of an actor type.

Motivation: Currently it is only possible to set a global time to live. It is an often requested feature that this should be tuneable per actor type.

Example:
```java
@TimeToLive(value=10, timeUnit = TimeUnit.SECONDS)
public interface User extends Actor{}
```