### PR TITLE
Optimise object allocation when using allOf with Streams.

### DIFF
--- a/commons/src/main/java/cloud/orbit/concurrent/Task.java
+++ b/commons/src/main/java/cloud/orbit/concurrent/Task.java
@@ -763,10 +763,7 @@ public class Task<T> extends CompletableFuture<T>
      */
     public static <F extends CompletableFuture<?>> Task<Void> allOf(Stream<F> cfs)
     {
-        final List<F> futureList = cfs.collect(Collectors.toList());
-        @SuppressWarnings("rawtypes")
-        final CompletableFuture[] futureArray = futureList.toArray(new CompletableFuture[futureList.size()]);
-        return from(CompletableFuture.allOf(futureArray));
+        return from(CompletableFuture.allOf(cfs.toArray(CompletableFuture[]::new)));
     }
 
     /**
@@ -793,7 +790,7 @@ public class Task<T> extends CompletableFuture<T>
      */
     public static <F extends CompletableFuture<?>> Task<Object> anyOf(Stream<F> cfs)
     {
-        return from(CompletableFuture.anyOf((CompletableFuture[]) cfs.toArray(size -> new CompletableFuture[size])));
+        return from(CompletableFuture.anyOf((CompletableFuture[]) cfs.toArray(CompletableFuture[]::new)));
     }
 
 }


### PR DESCRIPTION
Motivation:

Profiler shows there is high object allocation when publishing to Streams at high rates.

Modifications:

Optimise allOf method.

Result:

Higher throughput.

```
Benchmark               Mode  Cnt        Score       Error  Units
TaskTest.testAllOfNew  thrpt  100  2101099.117 ± 43901.991  ops/s
TaskTest.testAllOfOld  thrpt  100  1474742.201 ± 28348.890  ops/s
```