### PR TITLE
JVM Shutdown Hook

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -443,6 +443,11 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
             return this;
         }
 
+        public Builder enableShutdownHook(final boolean enableShutdownHook) {
+            this.enableShutdownHook = enableShutdownHook;
+            return this;
+        }
+
         public Stage build()
         {
             final Stage stage = new Stage();

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -911,7 +911,10 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
 
         if(enableShutdownHook) {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                this.stop().join();
+                if(state == NodeCapabilities.NodeState.RUNNING)
+                {
+                    this.stop().join();
+                }
             }));
         }
 

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -918,7 +918,7 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
                     {
                         if (state == NodeCapabilities.NodeState.RUNNING)
                         {
-                            this.stop().join();
+                            this.doStop().join();
                         }
                     }
                 });
@@ -972,8 +972,26 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
         this.extensions.add(extension);
     }
 
+
     @Override
     public Task<?> stop()
+    {
+        if(shutdownHook != null) {
+            try
+            {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+                shutdownHook = null;
+            }
+            catch (IllegalStateException ex)
+            {
+                // VM is already shutting down so just eat the error
+            }
+        }
+
+        return doStop();
+    }
+
+    private Task<?> doStop()
     {
         if (getState() != NodeCapabilities.NodeState.RUNNING)
         {
@@ -1020,17 +1038,7 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
         state = NodeCapabilities.NodeState.STOPPED;
         logger.debug("Stop done");
 
-        if(shutdownHook != null) {
-            try
-            {
-                Runtime.getRuntime().removeShutdownHook(shutdownHook);
-                shutdownHook = null;
-            }
-            catch (IllegalStateException ex)
-            {
-                // VM is already shutting down so just eat the error
-            }
-        }
+
 
         return Task.done();
     }

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -1021,8 +1021,15 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
         logger.debug("Stop done");
 
         if(shutdownHook != null) {
-            Runtime.getRuntime().removeShutdownHook(shutdownHook);
-            shutdownHook = null;
+            try
+            {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+                shutdownHook = null;
+            }
+            catch (IllegalStateException ex)
+            {
+                // VM is already shutting down so just eat the error
+            }
         }
 
         return Task.done();

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -205,6 +205,8 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
     @Config("orbit.actors.broadcastActorDeactivations")
     private boolean broadcastActorDeactivations = true;
 
+    private boolean enableShutdownHook = true;
+
     private volatile NodeCapabilities.NodeState state;
 
     private ClusterPeer clusterPeer;
@@ -272,6 +274,7 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
         private Boolean broadcastActorDeactivations = null;
         private Long deactivationTimeoutMillis;
         private Integer concurrentDeactivations;
+        private Boolean enableShutdownHook = null;
 
         private Timer timer;
 
@@ -468,6 +471,7 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
             if(deactivationTimeoutMillis != null) stage.setDeactivationTimeout(deactivationTimeoutMillis);
             if(concurrentDeactivations != null) stage.setConcurrentDeactivations(concurrentDeactivations);
             if(broadcastActorDeactivations != null) stage.setBroadcastActorDeactivations(broadcastActorDeactivations);
+            if(enableShutdownHook != null) stage.setEnableShutdownHook(enableShutdownHook);
             return stage;
         }
 
@@ -647,6 +651,10 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
     public void setBroadcastActorDeactivations(boolean broadcastActorDeactivation)
     {
         this.broadcastActorDeactivations = broadcastActorDeactivation;
+    }
+
+    public void setEnableShutdownHook(boolean enableShutdownHook) {
+        this.enableShutdownHook = enableShutdownHook;
     }
 
     @Override
@@ -895,6 +903,12 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
         await(startPromise);
 
         logger.info("Stage started [{}]", runtimeIdentity());
+
+        if(enableShutdownHook) {
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                this.stop().join();
+            }));
+        }
 
         return Task.done();
     }

--- a/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/Stage.java
@@ -913,7 +913,7 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
         if(enableShutdownHook) {
             if(shutdownHook == null) {
                 shutdownHook = new Thread(() -> {
-                    if(state == NodeCapabilities.NodeState.RUNNING)
+                    if (state == NodeCapabilities.NodeState.RUNNING)
                     {
                         this.stop().join();
                     }
@@ -1015,6 +1015,11 @@ public class Stage implements Startable, ActorRuntime, RuntimeActions
 
         state = NodeCapabilities.NodeState.STOPPED;
         logger.debug("Stop done");
+
+        if(shutdownHook != null) {
+            Runtime.getRuntime().removeShutdownHook(shutdownHook);
+            shutdownHook = null;
+        }
 
         return Task.done();
     }


### PR DESCRIPTION
Add a JVM shutdown hook option to Orbit.
This is particularly useful if your JVM shuts down in a controlled fashion but is initiated from outside the VM, such as a SIGTERM during docker shutdown.