### PR TITLE
Replace toArray(new T[size]) with toArray(new T[0]) to allow the VM t…

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/FastActorClassFinder.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/FastActorClassFinder.java
@@ -175,7 +175,7 @@ public class FastActorClassFinder implements ActorClassFinder
             if (tmp.size() > 0)
             {
                 tmp.add("cloud.orbit"); // internal actors
-                return tmp.toArray(new String[tmp.size()]);
+                return tmp.toArray(new String[0]);
             }
         }
         return actorBasePackages; // scan entire classpath

--- a/commons/src/main/java/cloud/orbit/concurrent/Task.java
+++ b/commons/src/main/java/cloud/orbit/concurrent/Task.java
@@ -767,7 +767,7 @@ public class Task<T> extends CompletableFuture<T>
      */
     public static <F extends CompletableFuture<?>, C extends Collection<F>> Task<Void> allOf(C cfs)
     {
-        return from(CompletableFuture.allOf(cfs.toArray(new CompletableFuture[cfs.size()])));
+        return from(CompletableFuture.allOf(cfs.toArray(new CompletableFuture[0])));
     }
 
     /**
@@ -794,7 +794,7 @@ public class Task<T> extends CompletableFuture<T>
      */
     public static <F extends CompletableFuture<?>> Task<Object> anyOf(Collection<F> cfs)
     {
-        return from(CompletableFuture.anyOf(cfs.toArray(new CompletableFuture[cfs.size()])));
+        return from(CompletableFuture.anyOf(cfs.toArray(new CompletableFuture[0])));
     }
 
     /**


### PR DESCRIPTION
…o optimize.

Motivation:

Using toArray(new T[0]) is usually the faster approach these days. We should use it.

See also https://shipilev.net/blog/2016/arrays-wisdom-ancients/#_conclusion.

Modifications:

Replace toArray(new T[size]) with toArray(new T[0]).

Result:

Faster code.