### PR TITLE
Orbit stage timer prone to terminating.

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeExecutionSerializer.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeExecutionSerializer.java
@@ -90,7 +90,7 @@ public class WaitFreeExecutionSerializer implements ExecutionSerializer, Executo
                     return source;
                 }))
         {
-            throw new IllegalStateException(String.format("Queue full for %s (%d > %d)", key, queue.size(), maxQueueSize));
+            return Task.fromException(new IllegalStateException(String.format("Queue full for %s (%d > %d)", key, queue.size(), maxQueueSize)));
         }
 
         // managing the size like this to avoid using ConcurrentLinkedQueue.size()


### PR DESCRIPTION
Motivation:

If an exception is thrown inside a timer task the timer will shut down and subsequent executions suppressed.

Modification:

Catch exceptions in the timer tasks.
Return exceptionally completed task in WaitFreeExceptionSerializer instead of throwing exception.

Result:

Stage timer should continue running until the stage is shutdown.

Fixes https://github.com/orbit/orbit/issues/316