### PR TITLE
Don't complete exceptional tasks normally

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeExecutionSerializer.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/concurrent/WaitFreeExecutionSerializer.java
@@ -189,7 +189,7 @@ public class WaitFreeExecutionSerializer implements ExecutionSerializer, Executo
         try
         {
             final Task<?> task = (Task) toRun.get();
-            if (task == null || task.isDone())
+            if (task == null || (task.isDone() && !task.isCompletedExceptionally()))
             {
                 taskFuture.complete(null);
             }


### PR DESCRIPTION
We observed an issue where something was completed exceptionally in an actor but at the caller the return value looked like it had completed normally. That led to checking this part.

I've also signed the CLA to be able to contribute.