### PR TITLE
DSL: Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ configureProject(":src:framework:orbit-runtime", [withKotlin, withTests, publish
 // DSL
 configureProject(":src:dsl:orbit-codegen", [withKotlin, withTests, publish])
 configureProject(":src:dsl:orbit-codegen-dsl", [withKotlin, withJava, withTests, publish])
+configureProject(":src:dsl:orbit-gradle-plugin", [withKotlin, withTests, publish])
 
 // Samples
 configureProject(":samples:helloworld", [withKotlin])
@@ -96,7 +97,7 @@ configure(withKotlin) {
     }
 
     dependencies {
-        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
+        compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutinesVersion")
     }

--- a/samples/helloworld-dsl-java/README.md
+++ b/samples/helloworld-dsl-java/README.md
@@ -1,0 +1,9 @@
+This sample is not part of the root project.
+
+To run this sample, first publish the root project:
+
+`$ gradle publish -x signMavenJavaPublication`
+
+Then run:
+
+`$ gradle run`

--- a/samples/helloworld-dsl-java/build.gradle
+++ b/samples/helloworld-dsl-java/build.gradle
@@ -1,0 +1,65 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+buildscript {
+    ext {
+        localOrbitVersion = '2.0.0-SNAPSHOT'
+        slf4jVersion = "1.7.26"
+    }
+
+    repositories {
+        maven {
+            url "$projectDir/../../src/dsl/orbit-codegen/build/repo"
+        }
+
+        maven {
+            url "$projectDir/../../src/dsl/orbit-codegen-dsl/build/repo"
+        }
+
+        maven {
+            url "$projectDir/../../src/dsl/orbit-gradle-plugin/build/repo"
+        }
+
+        mavenCentral()
+        jcenter()
+    }
+
+    dependencies {
+        classpath group: 'cloud.orbit', name: 'orbit-gradle-plugin', version: localOrbitVersion
+    }
+}
+
+apply plugin: 'application'
+apply plugin: 'cloud.orbit.dsl'
+
+mainClassName = "orbit.helloworld.dsl.App"
+
+repositories {
+    maven {
+        url "$projectDir/../../src/framework/orbit-commons/build/repo"
+    }
+
+    maven {
+        url "$projectDir/../../src/framework/orbit-core/build/repo"
+    }
+
+    maven {
+        url "$projectDir/../../src/framework/orbit-runtime/build/repo"
+    }
+
+    mavenCentral()
+    jcenter()
+}
+
+dependencies {
+    implementation("cloud.orbit:orbit-runtime:$localOrbitVersion")
+    implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+}
+
+compileJava {
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+}

--- a/samples/helloworld-dsl-java/settings.gradle
+++ b/samples/helloworld-dsl-java/settings.gradle
@@ -1,0 +1,7 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+rootProject.name = "orbit-helloworld-dsl-java"

--- a/samples/helloworld-dsl-java/src/main/java/orbit/helloworld/dsl/App.java
+++ b/samples/helloworld-dsl-java/src/main/java/orbit/helloworld/dsl/App.java
@@ -1,0 +1,38 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package orbit.helloworld.dsl;
+
+import cloud.orbit.common.logging.Logger;
+import cloud.orbit.core.actor.AbstractActor;
+import cloud.orbit.runtime.stage.Stage;
+import orbit.helloworld.dsl.data.Greeting;
+
+import java.util.concurrent.CompletableFuture;
+
+import static cloud.orbit.common.logging.Logging.getLogger;
+
+public class App {
+    public static void main(String[] args) {
+        Logger logger = getLogger("app");
+        Stage stage = new Stage();
+
+        stage.start().thenCompose(ignored -> {
+            Greeter greeter = stage.getActorProxyFactory().getReference(Greeter.class, "test");
+            return greeter.greet("Cesar").thenCompose(greeting -> {
+                logger.info(greeting.getGreeting());
+                return stage.stop();
+            });
+        }).join();
+    }
+
+    public static class GreeterActor extends AbstractActor implements Greeter {
+        @Override
+        public CompletableFuture<Greeting> greet(String name) {
+            return CompletableFuture.completedFuture(new Greeting("Hello " + name + "!"));
+        }
+    }
+}

--- a/samples/helloworld-dsl-java/src/main/orbit/orbit/helloworld/dsl/data/greeting.orbit
+++ b/samples/helloworld-dsl-java/src/main/orbit/orbit/helloworld/dsl/data/greeting.orbit
@@ -1,0 +1,3 @@
+data Greeting {
+    string greeting = 1;
+}

--- a/samples/helloworld-dsl-java/src/main/orbit/orbit/helloworld/dsl/greeter.orbit
+++ b/samples/helloworld-dsl-java/src/main/orbit/orbit/helloworld/dsl/greeter.orbit
@@ -1,0 +1,3 @@
+grain Greeter {
+    Greeting greet(string name);
+}

--- a/samples/helloworld-dsl-java/src/main/orbit/orbit/helloworld/dsl/greeter.orbit
+++ b/samples/helloworld-dsl-java/src/main/orbit/orbit/helloworld/dsl/greeter.orbit
@@ -1,3 +1,3 @@
-grain Greeter {
+actor Greeter {
     Greeting greet(string name);
 }

--- a/samples/helloworld-dsl/README.md
+++ b/samples/helloworld-dsl/README.md
@@ -1,0 +1,9 @@
+This sample is not part of the root project.
+
+To run this sample, first publish the root project:
+
+`$ gradle publish -x signMavenJavaPublication`
+
+Then run:
+
+`$ gradle run`

--- a/samples/helloworld-dsl/build.gradle
+++ b/samples/helloworld-dsl/build.gradle
@@ -1,0 +1,82 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+buildscript {
+    ext {
+        localOrbitVersion = '2.0.0-SNAPSHOT'
+        kotlinVersion = "1.3.21"
+        coroutinesVersion = "1.1.1"
+        slf4jVersion = "1.7.26"
+    }
+
+    repositories {
+        maven {
+            url "$projectDir/../../src/dsl/orbit-codegen/build/repo"
+        }
+
+        maven {
+            url "$projectDir/../../src/dsl/orbit-codegen-dsl/build/repo"
+        }
+
+        maven {
+            url "$projectDir/../../src/dsl/orbit-gradle-plugin/build/repo"
+        }
+
+        mavenCentral()
+        jcenter()
+    }
+
+    dependencies {
+        classpath group: 'org.jetbrains.kotlin', name :'kotlin-gradle-plugin', version: kotlinVersion
+        classpath group: 'cloud.orbit', name: 'orbit-gradle-plugin', version: localOrbitVersion
+    }
+}
+
+apply plugin: 'kotlin'
+apply plugin: 'application'
+apply plugin: 'cloud.orbit.dsl'
+
+mainClassName = "orbit.helloworld.dsl.AppKt"
+
+repositories {
+    maven {
+        url "$projectDir/../../src/framework/orbit-commons/build/repo"
+    }
+
+    maven {
+        url "$projectDir/../../src/framework/orbit-core/build/repo"
+    }
+
+    maven {
+        url "$projectDir/../../src/framework/orbit-runtime/build/repo"
+    }
+
+    mavenCentral()
+    jcenter()
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutinesVersion")
+
+    implementation("cloud.orbit:orbit-runtime:$localOrbitVersion")
+    implementation("org.slf4j:slf4j-simple:$slf4jVersion")
+}
+
+compileJava {
+    sourceCompatibility = "1.8"
+    targetCompatibility = "1.8"
+}
+
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+        freeCompilerArgs = ["-Xjvm-default=enable"]
+    }
+
+    dependsOn generateOrbitSource
+}

--- a/samples/helloworld-dsl/settings.gradle
+++ b/samples/helloworld-dsl/settings.gradle
@@ -1,0 +1,7 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+rootProject.name = "orbit-helloworld-dsl"

--- a/samples/helloworld-dsl/src/main/kotlin/orbit/helloworld/dsl/App.kt
+++ b/samples/helloworld-dsl/src/main/kotlin/orbit/helloworld/dsl/App.kt
@@ -1,0 +1,35 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package orbit.helloworld.dsl
+
+import cloud.orbit.common.logging.getLogger
+import cloud.orbit.core.actor.AbstractActor
+import cloud.orbit.core.actor.ActorWithStringKey
+import cloud.orbit.core.actor.getReference
+import cloud.orbit.runtime.stage.Stage
+import cloud.orbit.runtime.stage.StageConfig
+import java.util.concurrent.CompletableFuture
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.runBlocking
+
+class GreeterActor : Greeter, AbstractActor() {
+    override fun greet(name: String): CompletableFuture<Greeting> {
+        return CompletableFuture.completedFuture(Greeting("Hello $name!"))
+    }
+}
+
+fun main(args: Array<String>) {
+    val logger = getLogger("app")
+    val stage = Stage()
+
+    runBlocking {
+        stage.start().await()
+        val greeter = stage.actorProxyFactory.getReference<Greeter>("test")
+        logger.info(greeter.greet("Cesar").await().greeting)
+        stage.stop().await()
+    }
+}

--- a/samples/helloworld-dsl/src/main/orbit/orbit/helloworld/dsl/greeter.orbit
+++ b/samples/helloworld-dsl/src/main/orbit/orbit/helloworld/dsl/greeter.orbit
@@ -1,0 +1,3 @@
+grain Greeter {
+    Greeting greet(string name);
+}

--- a/samples/helloworld-dsl/src/main/orbit/orbit/helloworld/dsl/greeter.orbit
+++ b/samples/helloworld-dsl/src/main/orbit/orbit/helloworld/dsl/greeter.orbit
@@ -1,3 +1,3 @@
-grain Greeter {
+actor Greeter {
     Greeting greet(string name);
 }

--- a/samples/helloworld-dsl/src/main/orbit/orbit/helloworld/dsl/greeting.orbit
+++ b/samples/helloworld-dsl/src/main/orbit/orbit/helloworld/dsl/greeting.orbit
@@ -1,0 +1,3 @@
+data Greeting {
+    string greeting = 1;
+}

--- a/samples/helloworld/src/main/kotlin/orbit/helloworld/App.kt
+++ b/samples/helloworld/src/main/kotlin/orbit/helloworld/App.kt
@@ -12,7 +12,6 @@ import cloud.orbit.core.actor.AbstractActor
 import cloud.orbit.core.actor.ActorWithNoKey
 import cloud.orbit.core.actor.getReference
 import cloud.orbit.runtime.stage.Stage
-import cloud.orbit.runtime.stage.StageConfig
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.future.await

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,8 @@ include(
 
 include(
         ":src:dsl:orbit-codegen",
-        ":src:dsl:orbit-codegen-dsl"
+        ":src:dsl:orbit-codegen-dsl",
+        ":src:dsl:orbit-gradle-plugin"
 )
 
 include(

--- a/src/dsl/orbit-codegen-dsl/src/main/antlr/cloud/orbit/dsl/Orbit.g4
+++ b/src/dsl/orbit-codegen-dsl/src/main/antlr/cloud/orbit/dsl/Orbit.g4
@@ -14,13 +14,13 @@ fragment SPACE: [ \n\r\t] ;
 
 file: declaration+ EOF ;
 
-declaration: enumDeclaration | grainDeclaration | dataDeclaration ;
+declaration: enumDeclaration | actorDeclaration | dataDeclaration ;
 
 enumDeclaration: ENUM name=ID LC_BRACE members=enumMember* RC_BRACE ;
 enumMember: name=ID EQUAL index=INT SEMI_COLON;
 
-grainDeclaration: GRAIN name=ID LC_BRACE methods=grainMethod* RC_BRACE ;
-grainMethod: returnType=ID name=ID L_PAREN (args=methodParam (COMMA args=methodParam)*)? R_PAREN SEMI_COLON;
+actorDeclaration: ACTOR name=ID LC_BRACE methods=actorMethod* RC_BRACE ;
+actorMethod: returnType=ID name=ID L_PAREN (args=methodParam (COMMA args=methodParam)*)? R_PAREN SEMI_COLON;
 methodParam: type=ID name=ID ;
 
 dataDeclaration: DATA name=ID LC_BRACE fields=dataField* RC_BRACE ;
@@ -30,7 +30,7 @@ dataField: type=ID name=ID EQUAL index=INT SEMI_COLON ;
 
 DATA: 'data' ;
 ENUM: 'enum' ;
-GRAIN: 'grain' ;
+ACTOR: 'actor' ;
 
 ID: ALPHA(ALPHA|DIGIT|'_')* ;
 INT: DIGIT+ ;

--- a/src/dsl/orbit-codegen-dsl/src/main/kotlin/cloud/orbit/dsl/OrbitFileParser.kt
+++ b/src/dsl/orbit-codegen-dsl/src/main/kotlin/cloud/orbit/dsl/OrbitFileParser.kt
@@ -13,7 +13,7 @@ import org.antlr.v4.runtime.CommonTokenStream
 class OrbitFileParser : OrbitBaseVisitor<Any>() {
     private val enums = mutableListOf<EnumDeclaration>()
     private val data = mutableListOf<DataDeclaration>()
-    private val grains = mutableListOf<GrainDeclaration>()
+    private val actors = mutableListOf<ActorDeclaration>()
 
     // This code is not thread safe. Need to find a way to pass the context into the visitor
     fun parse(input: String, packageName: String): CompilationUnit {
@@ -21,7 +21,7 @@ class OrbitFileParser : OrbitBaseVisitor<Any>() {
         val lexer = OrbitLexer(CharStreams.fromString(input))
         val parser = OrbitParser(CommonTokenStream(lexer))
 
-        grains.clear()
+        actors.clear()
         data.clear()
 
         visitFile(parser.file())
@@ -30,7 +30,7 @@ class OrbitFileParser : OrbitBaseVisitor<Any>() {
             packageName,
             enums,
             data,
-            grains
+            actors
         )
     }
 
@@ -52,14 +52,14 @@ class OrbitFileParser : OrbitBaseVisitor<Any>() {
                 .map { DataField(it.name.text, Type(it.type.text), it.index.text.toInt()) }
                 .toList()))
 
-    override fun visitGrainDeclaration(ctx: OrbitParser.GrainDeclarationContext?) = grains.add(
-        GrainDeclaration(
+    override fun visitActorDeclaration(ctx: OrbitParser.ActorDeclarationContext?) = actors.add(
+        ActorDeclaration(
             ctx!!.name.text,
             ctx.children
                 .asSequence()
-                .filterIsInstance(OrbitParser.GrainMethodContext::class.java)
+                .filterIsInstance(OrbitParser.ActorMethodContext::class.java)
                 .map { m ->
-                    GrainMethod(
+                    ActorMethod(
                         name = m.name.text,
                         returnType = Type(m.returnType.text),
                         params = m.children

--- a/src/dsl/orbit-codegen-dsl/src/test/kotlin/cloud/orbit/dsl/OrbitFileLexerTest.kt
+++ b/src/dsl/orbit-codegen-dsl/src/test/kotlin/cloud/orbit/dsl/OrbitFileLexerTest.kt
@@ -27,7 +27,7 @@ class OrbitFileLexerTest {
         "a_",
         "Enum",
         "Data",
-        "Grain"
+        "Actor"
     )
         .map { testSingleToken("Id", it, OrbitLexer.ID) }
 
@@ -45,7 +45,7 @@ class OrbitFileLexerTest {
     fun tokenizeKeywords() = mapOf(
         "enum" to OrbitLexer.ENUM,
         "data" to OrbitLexer.DATA,
-        "grain" to OrbitLexer.GRAIN
+        "actor" to OrbitLexer.ACTOR
     )
         .map { testSingleToken("Keyword", it.key, it.value) }
 
@@ -70,7 +70,7 @@ class OrbitFileLexerTest {
             //Lots of comments
 
             // Comment
-            grain MyGrain{
+            actor MyActor{
                 // Comment
                 int no_args();
                 void one_arg(RGB a); // Comment
@@ -126,19 +126,19 @@ class OrbitFileLexerTest {
 
             "}" to OrbitLexer.RC_BRACE,
 
-            // ==== Grain ====
-            "grain" to OrbitLexer.GRAIN,
-            "MyGrain" to OrbitLexer.ID,
+            // ==== Actor ====
+            "actor" to OrbitLexer.ACTOR,
+            "MyActor" to OrbitLexer.ID,
             "{" to OrbitLexer.LC_BRACE,
 
-            // Grain method
+            // Actor method
             "int" to OrbitLexer.ID,
             "no_args" to OrbitLexer.ID,
             "(" to OrbitLexer.L_PAREN,
             ")" to OrbitLexer.R_PAREN,
             ";" to OrbitLexer.SEMI_COLON,
 
-            // Grain method
+            // Actor method
             "void" to OrbitLexer.ID,
             "one_arg" to OrbitLexer.ID,
             "(" to OrbitLexer.L_PAREN,
@@ -147,7 +147,7 @@ class OrbitFileLexerTest {
             ")" to OrbitLexer.R_PAREN,
             ";" to OrbitLexer.SEMI_COLON,
 
-            // Grain method
+            // Actor method
             "RGB" to OrbitLexer.ID,
             "multiple_args" to OrbitLexer.ID,
             "(" to OrbitLexer.L_PAREN,

--- a/src/dsl/orbit-codegen-dsl/src/test/kotlin/cloud/orbit/dsl/OrbitFileParserTest.kt
+++ b/src/dsl/orbit-codegen-dsl/src/test/kotlin/cloud/orbit/dsl/OrbitFileParserTest.kt
@@ -144,12 +144,12 @@ class OrbitFileParserTest {
     }
 
     @Test
-    fun parseGrain_Empty() {
-        val text = "grain foo{}"
+    fun parseActor_Empty() {
+        val text = "actor foo{}"
 
         val expectedCu = CompilationUnit(
             FAKE_PACKAGE_NAME,
-            grains = listOf(GrainDeclaration("foo"))
+            actors = listOf(ActorDeclaration("foo"))
         )
 
         val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
@@ -158,19 +158,19 @@ class OrbitFileParserTest {
     }
 
     @Test
-    fun parseGrain_SingleMethod() {
+    fun parseActor_SingleMethod() {
         val text = """
-            grain foo {
+            actor foo {
                 void bar();
             }
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
             FAKE_PACKAGE_NAME,
-            grains = listOf(
-                GrainDeclaration(
+            actors = listOf(
+                ActorDeclaration(
                     "foo",
-                    methods = listOf(GrainMethod("bar", Type("void")))
+                    methods = listOf(ActorMethod("bar", Type("void")))
                 )
             )
         )
@@ -181,9 +181,9 @@ class OrbitFileParserTest {
     }
 
     @Test
-    fun parseGrain_MultipleMethods() {
+    fun parseActor_MultipleMethods() {
         val text = """
-            grain foo {
+            actor foo {
                 void bar();
                 void baz();
             }
@@ -191,12 +191,12 @@ class OrbitFileParserTest {
 
         val expectedCu = CompilationUnit(
             FAKE_PACKAGE_NAME,
-            grains = listOf(
-                GrainDeclaration(
+            actors = listOf(
+                ActorDeclaration(
                     "foo",
                     methods = listOf(
-                        GrainMethod("bar", Type("void")),
-                        GrainMethod("baz", Type("void"))
+                        ActorMethod("bar", Type("void")),
+                        ActorMethod("baz", Type("void"))
                     )
                 )
             )
@@ -208,20 +208,20 @@ class OrbitFileParserTest {
     }
 
     @Test
-    fun parseGrain_MethodWithOneParam() {
+    fun parseActor_MethodWithOneParam() {
         val text = """
-            grain foo {
+            actor foo {
                 void bar(int k);
             }
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
             FAKE_PACKAGE_NAME,
-            grains = listOf(
-                GrainDeclaration(
+            actors = listOf(
+                ActorDeclaration(
                     "foo",
                     methods = listOf(
-                        GrainMethod(
+                        ActorMethod(
                             "bar", Type("void"),
                             params = listOf(MethodParameter("k", Type("int")))
                         )
@@ -236,20 +236,20 @@ class OrbitFileParserTest {
     }
 
     @Test
-    fun parseGrain_MethodWithMultipleParams() {
+    fun parseActor_MethodWithMultipleParams() {
         val text = """
-            grain foo {
+            actor foo {
                 void bar(int arg1, RGB arg2);
             }
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
             FAKE_PACKAGE_NAME,
-            grains = listOf(
-                GrainDeclaration(
+            actors = listOf(
+                ActorDeclaration(
                     "foo",
                     methods = listOf(
-                        GrainMethod(
+                        ActorMethod(
                             "bar", Type("void"),
                             params = listOf(
                                 MethodParameter("arg1", Type("int")),
@@ -287,7 +287,7 @@ class OrbitFileParserTest {
             //Lots of comments
 
             // Comment
-            grain MyGrain{
+            actor MyActor{
                 // Comment
                 int no_args();
                 void one_arg(RGB a); // Comment
@@ -318,18 +318,18 @@ class OrbitFileParserTest {
                     )
                 )
             ),
-            grains = listOf(
-                GrainDeclaration(
-                    "MyGrain",
+            actors = listOf(
+                ActorDeclaration(
+                    "MyActor",
                     methods = listOf(
-                        GrainMethod("no_args", Type("int")),
-                        GrainMethod(
+                        ActorMethod("no_args", Type("int")),
+                        ActorMethod(
                             "one_arg", Type("void"),
                             params = listOf(
                                 MethodParameter("a", Type("RGB"))
                             )
                         ),
-                        GrainMethod(
+                        ActorMethod(
                             "multiple_args", Type("RGB"),
                             params = listOf(
                                 MethodParameter("arg1", Type("RGB")),

--- a/src/dsl/orbit-codegen/src/main/kotlin/cloud/orbit/dsl/ast/ActorDeclaration.kt
+++ b/src/dsl/orbit-codegen/src/main/kotlin/cloud/orbit/dsl/ast/ActorDeclaration.kt
@@ -6,7 +6,7 @@
 
 package cloud.orbit.dsl.ast
 
-data class GrainDeclaration(
+data class ActorDeclaration(
     override val name: String,
-    val methods: List<GrainMethod> = emptyList()
+    val methods: List<ActorMethod> = emptyList()
 ) : Declaration

--- a/src/dsl/orbit-codegen/src/main/kotlin/cloud/orbit/dsl/ast/ActorMethod.kt
+++ b/src/dsl/orbit-codegen/src/main/kotlin/cloud/orbit/dsl/ast/ActorMethod.kt
@@ -6,7 +6,7 @@
 
 package cloud.orbit.dsl.ast
 
-data class GrainMethod(
+data class ActorMethod(
     val name: String,
     val returnType: Type,
     val params: List<MethodParameter> = emptyList()

--- a/src/dsl/orbit-codegen/src/main/kotlin/cloud/orbit/dsl/ast/AstVisitor.kt
+++ b/src/dsl/orbit-codegen/src/main/kotlin/cloud/orbit/dsl/ast/AstVisitor.kt
@@ -8,7 +8,7 @@ package cloud.orbit.dsl.ast
 
 abstract class AstVisitor {
     open fun visitCompilationUnit(cu: CompilationUnit) {
-        (cu.enums.asSequence() + cu.data.asSequence() + cu.grains.asSequence())
+        (cu.enums.asSequence() + cu.data.asSequence() + cu.actors.asSequence())
             .forEach { visitNode(it) }
     }
 
@@ -17,7 +17,7 @@ abstract class AstVisitor {
             is Declaration -> visitDeclaration(node)
             is EnumMember -> visitEnumMember(node)
             is DataField -> visitDataField(node)
-            is GrainMethod -> visitGrainMethod(node)
+            is ActorMethod -> visitActorMethod(node)
         }
     }
 
@@ -25,7 +25,7 @@ abstract class AstVisitor {
         when (declaration) {
             is EnumDeclaration -> visitEnumDeclaration(declaration)
             is DataDeclaration -> visitDataDeclaration(declaration)
-            is GrainDeclaration -> visitGrainDeclaration(declaration)
+            is ActorDeclaration -> visitActorDeclaration(declaration)
         }
     }
 
@@ -43,10 +43,10 @@ abstract class AstVisitor {
     open fun visitDataField(field: DataField) {
     }
 
-    open fun visitGrainDeclaration(grain: GrainDeclaration) {
-        grain.methods.forEach { visitNode(it) }
+    open fun visitActorDeclaration(actor: ActorDeclaration) {
+        actor.methods.forEach { visitNode(it) }
     }
 
-    open fun visitGrainMethod(method: GrainMethod) {
+    open fun visitActorMethod(method: ActorMethod) {
     }
 }

--- a/src/dsl/orbit-codegen/src/main/kotlin/cloud/orbit/dsl/ast/CompilationUnit.kt
+++ b/src/dsl/orbit-codegen/src/main/kotlin/cloud/orbit/dsl/ast/CompilationUnit.kt
@@ -10,5 +10,5 @@ data class CompilationUnit(
     val packageName: String,
     val enums: List<EnumDeclaration> = emptyList(),
     val data: List<DataDeclaration> = emptyList(),
-    val grains: List<GrainDeclaration> = emptyList()
+    val actors: List<ActorDeclaration> = emptyList()
 )

--- a/src/dsl/orbit-codegen/src/main/kotlin/cloud/orbit/dsl/java/JavaCodeGenerator.kt
+++ b/src/dsl/orbit-codegen/src/main/kotlin/cloud/orbit/dsl/java/JavaCodeGenerator.kt
@@ -73,12 +73,12 @@ internal class JavaCodeGenerator(private val knownTypes: Map<Type, TypeName>) : 
         generatedTypes.add(CompiledType(packageName, classSpec.build()))
     }
 
-    override fun visitGrainDeclaration(grain: GrainDeclaration) {
+    override fun visitActorDeclaration(actor: ActorDeclaration) {
         val classSpec = TypeSpec
-            .interfaceBuilder(grain.name)
+            .interfaceBuilder(actor.name)
             .addModifiers(Modifier.PUBLIC)
             .addSuperinterface(orbitActorWithStringKeyInterface)
-            .addMethods(grain.methods.map {
+            .addMethods(actor.methods.map {
                 MethodSpec.methodBuilder(it.name)
                     .addModifiers(Modifier.ABSTRACT, Modifier.PUBLIC)
                     .returns(ParameterizedTypeName.get(completableFutureClass, knownTypes[it.returnType]!!.box()))

--- a/src/dsl/orbit-codegen/src/test/kotlin/cloud/orbit/dsl/java/JavaCodeGeneratorTest.kt
+++ b/src/dsl/orbit-codegen/src/test/kotlin/cloud/orbit/dsl/java/JavaCodeGeneratorTest.kt
@@ -139,10 +139,10 @@ class JavaCodeGeneratorTest {
     }
 
     @Test
-    fun generateGrain_Empty() {
-        val cu = CompilationUnit(PACKAGE_NAME, grains = listOf(GrainDeclaration("grain1")))
+    fun generateActor_Empty() {
+        val cu = CompilationUnit(PACKAGE_NAME, actors = listOf(ActorDeclaration("actor1")))
 
-        val expectedSource = "public interface grain1 extends cloud.orbit.core.actor.ActorWithStringKey { }"
+        val expectedSource = "public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey { }"
 
         assertOneElement(generateSource_minimalPipeline(cu)).run {
             Assertions.assertEquals(PACKAGE_NAME, this.packageName)
@@ -151,15 +151,15 @@ class JavaCodeGeneratorTest {
     }
 
     @Test
-    fun generateGrain_SingleMethod() {
+    fun generateActor_SingleMethod() {
         val cu = CompilationUnit(
-            PACKAGE_NAME, grains = listOf(
-                GrainDeclaration("grain1", listOf(GrainMethod("method1", Type("string"))))
+            PACKAGE_NAME, actors = listOf(
+                ActorDeclaration("actor1", listOf(ActorMethod("method1", Type("string"))))
             )
         )
 
         val expectedSource = """
-            public interface grain1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
                 java.util.concurrent.CompletableFuture<java.lang.String> method1();
             }
         """
@@ -171,20 +171,20 @@ class JavaCodeGeneratorTest {
     }
 
     @Test
-    fun generateGrain_MultipleMethods() {
+    fun generateActor_MultipleMethods() {
         val cu = CompilationUnit(
-            PACKAGE_NAME, grains = listOf(
-                GrainDeclaration(
-                    "grain1", listOf(
-                        GrainMethod("method1", Type("string")),
-                        GrainMethod("method2", Type("string"))
+            PACKAGE_NAME, actors = listOf(
+                ActorDeclaration(
+                    "actor1", listOf(
+                        ActorMethod("method1", Type("string")),
+                        ActorMethod("method2", Type("string"))
                     )
                 )
             )
         )
 
         val expectedSource = """
-            public interface grain1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
                 java.util.concurrent.CompletableFuture<java.lang.String> method1();
                 java.util.concurrent.CompletableFuture<java.lang.String> method2();
             }
@@ -197,12 +197,12 @@ class JavaCodeGeneratorTest {
     }
 
     @Test
-    fun generateGrain_SingleParamMethod() {
+    fun generateActor_SingleParamMethod() {
         val cu = CompilationUnit(
-            PACKAGE_NAME, grains = listOf(
-                GrainDeclaration(
-                    "grain1", listOf(
-                        GrainMethod(
+            PACKAGE_NAME, actors = listOf(
+                ActorDeclaration(
+                    "actor1", listOf(
+                        ActorMethod(
                             "method1",
                             Type("string"),
                             params = listOf(MethodParameter("p1", Type("int32")))
@@ -213,7 +213,7 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface grain1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
                 java.util.concurrent.CompletableFuture<java.lang.String> method1(int p1);
             }
         """
@@ -225,12 +225,12 @@ class JavaCodeGeneratorTest {
     }
 
     @Test
-    fun generateGrain_MultipleParamsMethod() {
+    fun generateActor_MultipleParamsMethod() {
         val cu = CompilationUnit(
-            PACKAGE_NAME, grains = listOf(
-                GrainDeclaration(
-                    "grain1", listOf(
-                        GrainMethod(
+            PACKAGE_NAME, actors = listOf(
+                ActorDeclaration(
+                    "actor1", listOf(
+                        ActorMethod(
                             "method1",
                             Type("string"),
                             params = listOf(
@@ -244,7 +244,7 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface grain1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
                 java.util.concurrent.CompletableFuture<java.lang.String> method1(int p1, int p2);
             }
         """
@@ -256,12 +256,12 @@ class JavaCodeGeneratorTest {
     }
 
     @Test
-    fun generateGrain_PrimitivesAreBoxedInReturnType() {
+    fun generateActor_PrimitivesAreBoxedInReturnType() {
         val cu = CompilationUnit(
-            PACKAGE_NAME, grains = listOf(
-                GrainDeclaration(
-                    "grain1", listOf(
-                        GrainMethod(
+            PACKAGE_NAME, actors = listOf(
+                ActorDeclaration(
+                    "actor1", listOf(
+                        ActorMethod(
                             "method1",
                             Type("int32"),
                             params = listOf(MethodParameter("p1", Type("int32")))
@@ -272,7 +272,7 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface grain1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
                 java.util.concurrent.CompletableFuture<java.lang.Integer> method1(int p1);
             }
         """

--- a/src/dsl/orbit-codegen/src/test/kotlin/cloud/orbit/dsl/java/JavaCodeGeneratorTest.kt
+++ b/src/dsl/orbit-codegen/src/test/kotlin/cloud/orbit/dsl/java/JavaCodeGeneratorTest.kt
@@ -142,7 +142,7 @@ class JavaCodeGeneratorTest {
     fun generateGrain_Empty() {
         val cu = CompilationUnit(PACKAGE_NAME, grains = listOf(GrainDeclaration("grain1")))
 
-        val expectedSource = "public interface grain1 extends cloud.orbit.actors.Actor { }"
+        val expectedSource = "public interface grain1 extends cloud.orbit.core.actor.ActorWithStringKey { }"
 
         assertOneElement(generateSource_minimalPipeline(cu)).run {
             Assertions.assertEquals(PACKAGE_NAME, this.packageName)
@@ -159,8 +159,8 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface grain1 extends cloud.orbit.actors.Actor  {
-                cloud.orbit.concurrent.Task<java.lang.String> method1();
+            public interface grain1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+                java.util.concurrent.CompletableFuture<java.lang.String> method1();
             }
         """
 
@@ -184,9 +184,9 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface grain1 extends cloud.orbit.actors.Actor  {
-                cloud.orbit.concurrent.Task<java.lang.String> method1();
-                cloud.orbit.concurrent.Task<java.lang.String> method2();
+            public interface grain1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+                java.util.concurrent.CompletableFuture<java.lang.String> method1();
+                java.util.concurrent.CompletableFuture<java.lang.String> method2();
             }
         """
 
@@ -213,8 +213,8 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface grain1 extends cloud.orbit.actors.Actor  {
-                cloud.orbit.concurrent.Task<java.lang.String> method1(int p1);
+            public interface grain1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+                java.util.concurrent.CompletableFuture<java.lang.String> method1(int p1);
             }
         """
 
@@ -244,8 +244,8 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface grain1 extends cloud.orbit.actors.Actor  {
-                cloud.orbit.concurrent.Task<java.lang.String> method1(int p1, int p2);
+            public interface grain1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+                java.util.concurrent.CompletableFuture<java.lang.String> method1(int p1, int p2);
             }
         """
 
@@ -272,8 +272,8 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface grain1 extends cloud.orbit.actors.Actor  {
-                cloud.orbit.concurrent.Task<java.lang.Integer> method1(int p1);
+            public interface grain1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+                java.util.concurrent.CompletableFuture<java.lang.Integer> method1(int p1);
             }
         """
 

--- a/src/dsl/orbit-codegen/src/test/kotlin/cloud/orbit/dsl/java/TypeIndexerTest.kt
+++ b/src/dsl/orbit-codegen/src/test/kotlin/cloud/orbit/dsl/java/TypeIndexerTest.kt
@@ -57,10 +57,10 @@ class TypeIndexerTest {
     }
 
     @Test
-    fun indexGrain() {
+    fun indexActor() {
         val actual = TypeIndexer().visitCompilationUnits(
             listOf(
-                CompilationUnit("foo", grains = listOf(GrainDeclaration("bar")))
+                CompilationUnit("foo", actors = listOf(ActorDeclaration("bar")))
             )
         )
 

--- a/src/dsl/orbit-gradle-plugin/build.gradle
+++ b/src/dsl/orbit-gradle-plugin/build.gradle
@@ -1,0 +1,22 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+plugins {
+    id 'java-gradle-plugin'
+}
+
+dependencies {
+    compile(project(":src:dsl:orbit-codegen-dsl"))
+}
+
+gradlePlugin {
+    plugins {
+        orbitPlugin {
+            id = 'cloud.orbit.dsl'
+            implementationClass = 'cloud.orbit.dsl.gradle.OrbitDslPlugin'
+        }
+    }
+}

--- a/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslCompilerRunner.kt
+++ b/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslCompilerRunner.kt
@@ -1,0 +1,60 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.gradle
+
+import cloud.orbit.dsl.OrbitFileParser
+import cloud.orbit.dsl.java.OrbitJavaCompiler
+import java.io.File
+
+class OrbitDslCompilerRunner {
+    fun run(spec: OrbitDslSpec) {
+        val inputDirectory = spec.orbitFiles.map { file ->
+            file to spec.inputDirectories.first { it.contains(file) }
+        }.toMap()
+
+        val parsedOrbitFiles = spec.orbitFiles.map {
+            OrbitFileParser().parse(it.readText(), getPackageNameFromFile(inputDirectory.getValue(it), it))
+        }
+
+        OrbitJavaCompiler()
+            .compile(parsedOrbitFiles)
+            .forEach {
+                it.writeToDirectory(spec.outputDirectory)
+            }
+    }
+
+    private fun getPackageNameFromFile(inputDirectory: File, f: File): String {
+        tailrec fun getPackageNameFromFile(file: File?, acc: MutableList<String>): List<String> {
+            if (file == null) {
+                return acc
+            }
+
+            acc.add(0, file.name)
+            return getPackageNameFromFile(file.parentFile, acc)
+        }
+
+        return getPackageNameFromFile(
+            f.relativeTo(inputDirectory).parentFile,
+            mutableListOf()
+        )
+            .joinToString(separator = ".")
+    }
+
+    private fun File.contains(file: File): Boolean {
+        var parent = file.parentFile
+
+        while (parent != null) {
+            if (this == parent) {
+                return true
+            }
+
+            parent = parent.parentFile
+        }
+
+        return false
+    }
+}

--- a/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslPlugin.kt
+++ b/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslPlugin.kt
@@ -1,0 +1,58 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.internal.plugins.DslObject
+import org.gradle.api.internal.tasks.DefaultSourceSet
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginConvention
+import java.io.File
+import javax.inject.Inject
+
+class OrbitDslPlugin : Plugin<Project> {
+    private val objectFactory: ObjectFactory
+
+    @Inject
+    constructor(objectFactory: ObjectFactory) {
+        this.objectFactory = objectFactory
+    }
+
+    override fun apply(project: Project) {
+        project.pluginManager.apply(JavaPlugin::class.java)
+
+        project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets.all { sourceSet ->
+            // Add an 'orbit' virtual directory mapping for each source set
+            val orbitDirectoryDelegate = OrbitDslSourceVirtualDirectoryImpl(
+                (sourceSet as DefaultSourceSet).displayName, objectFactory)
+            DslObject(sourceSet).convention.plugins["orbit"] = orbitDirectoryDelegate
+            orbitDirectoryDelegate.orbit.srcDir("src/${sourceSet.name}/orbit")
+            sourceSet.allSource.source(orbitDirectoryDelegate.orbit)
+
+            // Create a code generation task that writes to the output directory
+            val taskName = sourceSet.getTaskName("generate", "OrbitSource")
+            val outputDirectory = File("${project.buildDir}/generated-src/orbit/${sourceSet.name}")
+
+            // Make the output of Orbit code generation an input to javac
+            sourceSet.java.srcDir(outputDirectory)
+
+            // Register the code generation task
+            project.tasks.register(taskName, OrbitDslTask::class.java) {
+                it.description = "Processes the ${sourceSet.name} Orbit DSL definitions."
+                it.source = orbitDirectoryDelegate.orbit
+                it.outputDirectory = outputDirectory
+            }
+
+            // Run task before compiling Java
+            project.tasks.named(sourceSet.compileJavaTaskName) {
+                it.dependsOn(taskName)
+            }
+        }
+    }
+}

--- a/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslSourceVirtualDirectory.kt
+++ b/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslSourceVirtualDirectory.kt
@@ -1,0 +1,19 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.gradle
+
+import groovy.lang.Closure
+import org.gradle.api.Action
+import org.gradle.api.file.SourceDirectorySet
+
+interface OrbitDslSourceVirtualDirectory {
+    val orbit: SourceDirectorySet
+
+    fun orbit(configureClosure: Closure<*>): OrbitDslSourceVirtualDirectory
+
+    fun orbit(configureAction: Action<in SourceDirectorySet>): OrbitDslSourceVirtualDirectory
+}

--- a/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslSourceVirtualDirectoryImpl.kt
+++ b/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslSourceVirtualDirectoryImpl.kt
@@ -1,0 +1,38 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.gradle
+
+import groovy.lang.Closure
+import org.gradle.api.Action
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.reflect.HasPublicType
+import org.gradle.api.reflect.TypeOf
+import org.gradle.api.reflect.TypeOf.typeOf
+import org.gradle.util.ConfigureUtil
+
+class OrbitDslSourceVirtualDirectoryImpl(
+    parentDisplayName: String,
+    objectFactory: ObjectFactory
+) : OrbitDslSourceVirtualDirectory, HasPublicType {
+    override val orbit: SourceDirectorySet =
+        objectFactory.sourceDirectorySet("$parentDisplayName.orbit", "$parentDisplayName Orbit source")
+
+    init {
+        orbit.filter.include("**/*.orbit")
+    }
+
+    override fun orbit(configureClosure: Closure<*>) = this.also {
+        ConfigureUtil.configure(configureClosure, orbit)
+    }
+
+    override fun orbit(configureAction: Action<in SourceDirectorySet>) = this.also {
+        configureAction.execute(orbit)
+    }
+
+    override fun getPublicType(): TypeOf<*> = typeOf(OrbitDslSourceVirtualDirectory::class.java)
+}

--- a/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslSpec.kt
+++ b/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslSpec.kt
@@ -1,0 +1,11 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.gradle
+
+import java.io.File
+
+data class OrbitDslSpec(val orbitFiles: Set<File>, val inputDirectories: Set<File>, val outputDirectory: File)

--- a/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslTask.kt
+++ b/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslTask.kt
@@ -1,0 +1,42 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.gradle
+
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.SourceTask
+import org.gradle.api.tasks.TaskAction
+import org.gradle.util.GFileUtils
+import java.io.File
+
+open class OrbitDslTask : SourceTask() {
+    @OutputDirectory
+    var outputDirectory: File? = null
+
+    private var sourceDirectorySet: SourceDirectorySet? = null
+
+    @TaskAction
+    fun execute() {
+        val orbitFiles = mutableSetOf<File>()
+        val sourceFiles = source.files
+
+        // Always clear the output directory and re-generate all sources
+        GFileUtils.cleanDirectory(outputDirectory!!)
+        orbitFiles.addAll(sourceFiles)
+
+        val spec = OrbitDslSpec(orbitFiles, sourceDirectorySet!!.srcDirs, outputDirectory!!)
+        OrbitDslCompilerRunner().run(spec)
+    }
+
+    override fun setSource(source: Any) {
+        super.setSource(source)
+
+        if (source is SourceDirectorySet) {
+            sourceDirectorySet = source
+        }
+    }
+}

--- a/src/dsl/orbit-gradle-plugin/src/test/kotlin/cloud/orbit/dsl/gradle/OrbitDslPluginTest.kt
+++ b/src/dsl/orbit-gradle-plugin/src/test/kotlin/cloud/orbit/dsl/gradle/OrbitDslPluginTest.kt
@@ -1,0 +1,42 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.gradle
+
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class OrbitDslPluginTest {
+    private val project = ProjectBuilder.builder().build()
+
+    @BeforeEach
+    fun setup() {
+        project.pluginManager.apply("cloud.orbit.dsl")
+    }
+
+    @Test
+    fun applyingPluginWorks() {
+        assertTrue(project.pluginManager.hasPlugin("cloud.orbit.dsl"))
+    }
+
+    @Test
+    fun appliesJavaPlugin() {
+        assertTrue(project.pluginManager.hasPlugin("java"))
+    }
+
+    @Test
+    fun registersSourceGenerationTask() {
+        assertNotNull(project.tasks.getByName("generateOrbitSource"))
+    }
+
+    @Test
+    fun addsDependencyToJavaCompilationTask() {
+        project.tasks.getByName("compileJava").dependsOn.contains("generateOrbitSource")
+    }
+}


### PR DESCRIPTION
A Gradle plugin for the Orbit DSL. The plugin takes care of the following:

- Applies the Java plugin, since we're generating Java
- Makes the `compileJava` task depend on the `generateOrbitSource` task to ensure we run before Java compilation
- Looks into `src/<sourceSet>/orbit` directories for `*.orbit` files and calls the DSL compiler to compile them to Java

The plugin supports adding extra source directories, e.g.:

```
sourceSets {
    main {
        orbit {
            srcDir 'src/main/moreorbit'
        }
    }
}
```

The new sample apps `helloworld-dsl` and `helloworld-dsl-java`  are not included in the root project because they need to apply the plugin, and Gradle doesn't support applying project plugins that are not defined in `buildSrc`. So you first have to `gradle publish` the root project to be able to build and run the samples.

I changed the Kotlin stdlib dependency from `implementation` to `compile` because some runtime APIs "leak" Kotlin (e.g. `Stage.start()` returns `Unit`). By changing it to `compile`, we pick the dependency transitively in code that depends on `orbit-runtime` (like the samples).

I also changed the DSL compiler to return `CompletableFuture` instead of task, and to have actors implement `ActorWithStringKey` (for now - DSL improvements for other key times to come in a separate PR).