### PR TITLE
Setup Gradle plugin publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ def withKotlin = []
 def withJava = []
 def withTests = []
 def publish = []
+def localPublish = []
 
 // Framework
 configureProject(":src:framework:orbit-commons", [withKotlin, withTests, publish])
@@ -23,7 +24,7 @@ configureProject(":src:framework:orbit-runtime", [withKotlin, withTests, publish
 // DSL
 configureProject(":src:dsl:orbit-codegen", [withKotlin, withTests, publish])
 configureProject(":src:dsl:orbit-codegen-dsl", [withKotlin, withJava, withTests, publish])
-configureProject(":src:dsl:orbit-gradle-plugin", [withKotlin, withTests, publish])
+configureProject(":src:dsl:orbit-gradle-plugin", [withKotlin, withTests, localPublish])
 
 // Samples
 configureProject(":samples:helloworld", [withKotlin])
@@ -254,5 +255,17 @@ configure(publish) {
 
     signing {
         sign publishing.publications.mavenJava
+    }
+}
+
+configure(localPublish) {
+    apply plugin: "maven-publish"
+
+    publishing {
+        repositories {
+            maven {
+                url("$buildDir/repo")
+            }
+        }
     }
 }

--- a/src/dsl/orbit-gradle-plugin/build.gradle
+++ b/src/dsl/orbit-gradle-plugin/build.gradle
@@ -5,6 +5,7 @@
  */
 
 plugins {
+    id "com.gradle.plugin-publish" version "0.10.1"
     id 'java-gradle-plugin'
 }
 
@@ -14,9 +15,23 @@ dependencies {
 
 gradlePlugin {
     plugins {
-        orbitPlugin {
+        orbitDslPlugin {
             id = 'cloud.orbit.dsl'
             implementationClass = 'cloud.orbit.dsl.gradle.OrbitDslPlugin'
+        }
+    }
+}
+
+pluginBundle {
+    website = orbitUrl
+    vcsUrl = orbitScmUrl
+    description = "A plugin to generate code from Orbit DSL files"
+
+    plugins {
+        orbitDslPlugin {
+            displayName = "Orbit DSL plugin"
+            tags = ['orbit']
+            version = orbitVersion
         }
     }
 }


### PR DESCRIPTION
Use the Gradle Plugin Publishing plugin to publish to https://plugins.gradle.org using the `publishPlugins` task.

When running the `publish` task, only publish to local directory.