### PR TITLE
DSL: throw and add file information on syntax errors

### DIFF
--- a/src/dsl/orbit-codegen-dsl/src/main/kotlin/cloud/orbit/dsl/OrbitDslException.kt
+++ b/src/dsl/orbit-codegen-dsl/src/main/kotlin/cloud/orbit/dsl/OrbitDslException.kt
@@ -1,0 +1,9 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+class OrbitDslException(message: String) : RuntimeException(message)

--- a/src/dsl/orbit-codegen-dsl/src/main/kotlin/cloud/orbit/dsl/OrbitFileParser.kt
+++ b/src/dsl/orbit-codegen-dsl/src/main/kotlin/cloud/orbit/dsl/OrbitFileParser.kt
@@ -17,6 +17,7 @@ import cloud.orbit.dsl.ast.MethodParameter
 import cloud.orbit.dsl.ast.Type
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.ConsoleErrorListener
 
 class OrbitFileParser : OrbitBaseVisitor<Any>() {
     private val enums = mutableListOf<EnumDeclaration>()
@@ -25,9 +26,11 @@ class OrbitFileParser : OrbitBaseVisitor<Any>() {
 
     // This code is not thread safe. Need to find a way to pass the context into the visitor
     fun parse(input: String, packageName: String): CompilationUnit {
-
         val lexer = OrbitLexer(CharStreams.fromString(input))
-        val parser = OrbitParser(CommonTokenStream(lexer))
+        val parser = OrbitParser(CommonTokenStream(lexer)).also {
+            it.addErrorListener(ThrowingErrorListener())
+            it.removeErrorListener(ConsoleErrorListener.INSTANCE)
+        }
 
         actors.clear()
         data.clear()

--- a/src/dsl/orbit-codegen-dsl/src/main/kotlin/cloud/orbit/dsl/ThrowingErrorListener.kt
+++ b/src/dsl/orbit-codegen-dsl/src/main/kotlin/cloud/orbit/dsl/ThrowingErrorListener.kt
@@ -1,0 +1,25 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import org.antlr.v4.runtime.BaseErrorListener
+import org.antlr.v4.runtime.RecognitionException
+import org.antlr.v4.runtime.Recognizer
+import org.antlr.v4.runtime.misc.ParseCancellationException
+
+class ThrowingErrorListener : BaseErrorListener() {
+    override fun syntaxError(
+        recognizer: Recognizer<*, *>?,
+        offendingSymbol: Any?,
+        line: Int,
+        charPositionInLine: Int,
+        msg: String?,
+        e: RecognitionException?
+    ) {
+        throw ParseCancellationException("line $line:$charPositionInLine: ${msg ?: "syntax error"}")
+    }
+}

--- a/src/dsl/orbit-codegen-dsl/src/test/kotlin/cloud/orbit/dsl/OrbitFileParserTest.kt
+++ b/src/dsl/orbit-codegen-dsl/src/test/kotlin/cloud/orbit/dsl/OrbitFileParserTest.kt
@@ -15,22 +15,33 @@ import cloud.orbit.dsl.ast.EnumDeclaration
 import cloud.orbit.dsl.ast.EnumMember
 import cloud.orbit.dsl.ast.MethodParameter
 import cloud.orbit.dsl.ast.Type
+import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class OrbitFileParserTest {
-    private val FAKE_PACKAGE_NAME = "cloud.orbit.test.some.package"
+    private val packageName = "cloud.orbit.test"
+
+    @Test
+    fun throwsOnSyntaxError() {
+        val text = "actor a {"
+
+        assertThrows<ParseCancellationException> {
+            OrbitFileParser().parse(text, packageName)
+        }
+    }
 
     @Test
     fun parseEnum_Empty() {
         val text = "enum foo{}"
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             enums = listOf(EnumDeclaration("foo"))
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -44,7 +55,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             enums = listOf(
                 EnumDeclaration(
                     "foo",
@@ -53,7 +64,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -68,7 +79,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             enums = listOf(
                 EnumDeclaration(
                     "foo",
@@ -80,7 +91,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -90,11 +101,11 @@ class OrbitFileParserTest {
         val text = "data foo{}"
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             data = listOf(DataDeclaration("foo"))
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -108,7 +119,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             data = listOf(
                 DataDeclaration(
                     "foo",
@@ -119,7 +130,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -134,7 +145,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             data = listOf(
                 DataDeclaration(
                     "foo",
@@ -146,7 +157,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -160,7 +171,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             data = listOf(
                 DataDeclaration(
                     "foo",
@@ -171,7 +182,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -185,7 +196,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             data = listOf(
                 DataDeclaration(
                     "foo",
@@ -208,7 +219,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -222,7 +233,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             data = listOf(
                 DataDeclaration(
                     "foo",
@@ -241,7 +252,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -255,7 +266,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             data = listOf(
                 DataDeclaration(
                     "foo",
@@ -274,7 +285,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -284,11 +295,11 @@ class OrbitFileParserTest {
         val text = "actor foo{}"
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             actors = listOf(ActorDeclaration("foo"))
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -302,7 +313,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             actors = listOf(
                 ActorDeclaration(
                     "foo",
@@ -311,7 +322,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -326,7 +337,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             actors = listOf(
                 ActorDeclaration(
                     "foo",
@@ -338,7 +349,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -352,7 +363,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             actors = listOf(
                 ActorDeclaration(
                     "foo",
@@ -366,7 +377,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -380,7 +391,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             actors = listOf(
                 ActorDeclaration(
                     "foo",
@@ -397,7 +408,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }
@@ -437,7 +448,7 @@ class OrbitFileParserTest {
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
-            FAKE_PACKAGE_NAME,
+            packageName,
             enums = listOf(
                 EnumDeclaration(
                     "RGB",
@@ -533,7 +544,7 @@ class OrbitFileParserTest {
             )
         )
 
-        val actualCu = OrbitFileParser().parse(text, FAKE_PACKAGE_NAME)
+        val actualCu = OrbitFileParser().parse(text, packageName)
 
         Assertions.assertEquals(expectedCu, actualCu)
     }

--- a/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslException.kt
+++ b/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslException.kt
@@ -6,11 +6,4 @@
 
 package cloud.orbit.dsl.gradle
 
-import java.io.File
-
-data class OrbitDslSpec(
-    val projectDirectory: File,
-    val orbitFiles: Set<File>,
-    val inputDirectories: Set<File>,
-    val outputDirectory: File
-)
+class OrbitDslException(message: String) : RuntimeException(message)

--- a/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslTask.kt
+++ b/src/dsl/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/dsl/gradle/OrbitDslTask.kt
@@ -28,7 +28,7 @@ open class OrbitDslTask : SourceTask() {
         GFileUtils.cleanDirectory(outputDirectory!!)
         orbitFiles.addAll(sourceFiles)
 
-        val spec = OrbitDslSpec(orbitFiles, sourceDirectorySet!!.srcDirs, outputDirectory!!)
+        val spec = OrbitDslSpec(project.projectDir, orbitFiles, sourceDirectorySet!!.srcDirs, outputDirectory!!)
         OrbitDslCompilerRunner().run(spec)
     }
 


### PR DESCRIPTION
#359 

Two fixes:

1. Fail the build on syntax errors in Orbit DSL files. ANTLR doesn't throw by default.
1. Show which file(s) have syntax errors.

Before:

```
line 3:0 missing ';' at '}'
```

Now:

```
src/main/orbit/orbit/helloworld/dsl/greeter.orbit: error: line 3:0: missing ';' at '}'
```