### PR TITLE
Rename Gradle plugin ID to 'cloud.orbit.plugin'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,9 @@ configureProject(":src:framework:orbit-runtime", [withKotlin, withJava, withTest
 configureProject(":src:dsl:orbit-dsl-ast", [withKotlin, withTests, publish])
 configureProject(":src:dsl:orbit-dsl-java", [withKotlin, withTests, publish])
 configureProject(":src:dsl:orbit-dsl-parsing", [withKotlin, withJava, withTests, publish])
-configureProject(":src:dsl:orbit-gradle-plugin", [withKotlin, withTests, localPublish])
+
+// Plugins
+configureProject(":src:plugins:orbit-gradle-plugin", [withKotlin, withTests, localPublish])
 
 // Benchmark
 configureProject(":src:benchmarks", [withKotlin, withJava])

--- a/samples/helloworld-dsl-java/build.gradle
+++ b/samples/helloworld-dsl-java/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         }
 
         maven {
-            url "$projectDir/../../src/dsl/orbit-gradle-plugin/build/repo"
+            url "$projectDir/../../src/plugins/orbit-gradle-plugin/build/repo"
         }
 
         mavenCentral()
@@ -37,7 +37,7 @@ buildscript {
 }
 
 apply plugin: 'application'
-apply plugin: 'cloud.orbit.dsl'
+apply plugin: 'cloud.orbit.plugin'
 
 mainClassName = "orbit.helloworld.dsl.App"
 

--- a/samples/helloworld-dsl/build.gradle
+++ b/samples/helloworld-dsl/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         }
 
         maven {
-            url "$projectDir/../../src/dsl/orbit-gradle-plugin/build/repo"
+            url "$projectDir/../../src/plugins/orbit-gradle-plugin/build/repo"
         }
 
         mavenCentral()
@@ -41,7 +41,7 @@ buildscript {
 
 apply plugin: 'kotlin'
 apply plugin: 'application'
-apply plugin: 'cloud.orbit.dsl'
+apply plugin: 'cloud.orbit.plugin'
 
 mainClassName = "orbit.helloworld.dsl.AppKt"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,8 +15,11 @@ include(
 include(
         ":src:dsl:orbit-dsl-ast",
         ":src:dsl:orbit-dsl-java",
-        ":src:dsl:orbit-dsl-parsing",
-        ":src:dsl:orbit-gradle-plugin"
+        ":src:dsl:orbit-dsl-parsing"
+)
+
+include(
+        ":src:plugins:orbit-gradle-plugin"
 )
 
 include(

--- a/src/plugins/orbit-gradle-plugin/build.gradle
+++ b/src/plugins/orbit-gradle-plugin/build.gradle
@@ -16,9 +16,9 @@ dependencies {
 
 gradlePlugin {
     plugins {
-        orbitDslPlugin {
-            id = 'cloud.orbit.dsl'
-            implementationClass = 'cloud.orbit.dsl.gradle.OrbitDslPlugin'
+        orbitPlugin {
+            id = 'cloud.orbit.plugin'
+            implementationClass = 'cloud.orbit.plugin.gradle.OrbitPlugin'
         }
     }
 }
@@ -26,12 +26,12 @@ gradlePlugin {
 pluginBundle {
     website = orbitUrl
     vcsUrl = orbitScmUrl
-    description = "A plugin to generate code from the Orbit DSL."
+    description = "A plugin for the Orbit distributed systems framework."
 
     plugins {
         orbitDslPlugin {
-            displayName = "Orbit DSL Plugin"
-            tags = ['orbit', 'codegen', 'dsl']
+            displayName = "Orbit Plugin"
+            tags = ['orbit', 'actor', 'distributed', 'framework']
             version = orbitVersion
         }
     }

--- a/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslCompilerRunner.kt
+++ b/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslCompilerRunner.kt
@@ -4,7 +4,7 @@
  See license in LICENSE.
  */
 
-package cloud.orbit.dsl.gradle
+package cloud.orbit.plugin.gradle
 
 import cloud.orbit.dsl.OrbitDslFileParser
 import cloud.orbit.dsl.ast.CompilationUnit

--- a/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslException.kt
+++ b/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslException.kt
@@ -4,6 +4,6 @@
  See license in LICENSE.
  */
 
-package cloud.orbit.dsl.gradle
+package cloud.orbit.plugin.gradle
 
 class OrbitDslException(message: String) : RuntimeException(message)

--- a/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslSourceVirtualDirectory.kt
+++ b/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslSourceVirtualDirectory.kt
@@ -4,7 +4,7 @@
  See license in LICENSE.
  */
 
-package cloud.orbit.dsl.gradle
+package cloud.orbit.plugin.gradle
 
 import groovy.lang.Closure
 import org.gradle.api.Action

--- a/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslSourceVirtualDirectoryImpl.kt
+++ b/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslSourceVirtualDirectoryImpl.kt
@@ -4,7 +4,7 @@
  See license in LICENSE.
  */
 
-package cloud.orbit.dsl.gradle
+package cloud.orbit.plugin.gradle
 
 import groovy.lang.Closure
 import org.gradle.api.Action

--- a/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslSpec.kt
+++ b/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslSpec.kt
@@ -4,7 +4,7 @@
  See license in LICENSE.
  */
 
-package cloud.orbit.dsl.gradle
+package cloud.orbit.plugin.gradle
 
 import java.io.File
 

--- a/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslTask.kt
+++ b/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslTask.kt
@@ -4,7 +4,7 @@
  See license in LICENSE.
  */
 
-package cloud.orbit.dsl.gradle
+package cloud.orbit.plugin.gradle
 
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.tasks.OutputDirectory
@@ -28,7 +28,12 @@ open class OrbitDslTask : SourceTask() {
         GFileUtils.cleanDirectory(outputDirectory!!)
         orbitFiles.addAll(sourceFiles)
 
-        val spec = OrbitDslSpec(project.projectDir, orbitFiles, sourceDirectorySet!!.srcDirs, outputDirectory!!)
+        val spec = OrbitDslSpec(
+            project.projectDir,
+            orbitFiles,
+            sourceDirectorySet!!.srcDirs,
+            outputDirectory!!
+        )
         OrbitDslCompilerRunner().run(spec)
     }
 

--- a/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitPlugin.kt
+++ b/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitPlugin.kt
@@ -4,7 +4,7 @@
  See license in LICENSE.
  */
 
-package cloud.orbit.dsl.gradle
+package cloud.orbit.plugin.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -16,7 +16,7 @@ import org.gradle.api.plugins.JavaPluginConvention
 import java.io.File
 import javax.inject.Inject
 
-class OrbitDslPlugin : Plugin<Project> {
+class OrbitPlugin : Plugin<Project> {
     private val objectFactory: ObjectFactory
 
     @Inject

--- a/src/plugins/orbit-gradle-plugin/src/test/kotlin/cloud/orbit/plugin/gradle/OrbitPluginTest.kt
+++ b/src/plugins/orbit-gradle-plugin/src/test/kotlin/cloud/orbit/plugin/gradle/OrbitPluginTest.kt
@@ -4,7 +4,7 @@
  See license in LICENSE.
  */
 
-package cloud.orbit.dsl.gradle
+package cloud.orbit.plugin.gradle
 
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -12,17 +12,17 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class OrbitDslPluginTest {
+class OrbitPluginTest {
     private val project = ProjectBuilder.builder().build()
 
     @BeforeEach
     fun setup() {
-        project.pluginManager.apply("cloud.orbit.dsl")
+        project.pluginManager.apply("cloud.orbit.plugin")
     }
 
     @Test
     fun applyingPluginWorks() {
-        assertTrue(project.pluginManager.hasPlugin("cloud.orbit.dsl"))
+        assertTrue(project.pluginManager.hasPlugin("cloud.orbit.plugin"))
     }
 
     @Test


### PR DESCRIPTION
Given we'll eventually have the Gradle plugin do more than just process DSL files, it makes sense to ID the plugin as just `cloud.orbit.plugin` rather than the more specific `cloud.orbit.dsl`.

Also moving the module from under the `src/dsl` directory the new `src/plugins` directory.