### PR TITLE
DSL: add syntax for specifying actor key type

### DIFF
--- a/samples/helloworld-dsl-java/src/main/java/orbit/helloworld/dsl/App.java
+++ b/samples/helloworld-dsl-java/src/main/java/orbit/helloworld/dsl/App.java
@@ -26,7 +26,7 @@ public class App {
         Stage stage = new Stage();
 
         stage.start().thenCompose(ignored -> {
-            Greeter greeter = stage.getActorProxyFactory().createProxy(Greeter.class, "test");
+            Greeter greeter = stage.getActorProxyFactory().createProxy(Greeter.class);
             return greeter.greet("Cesar").thenCompose(greetings -> {
                 greetings.forEach((language, greeting) ->
                         logger.info("In {}: {}", greeting.getLanguage(), greeting.getText()));

--- a/samples/helloworld-dsl/src/main/kotlin/orbit/helloworld/dsl/App.kt
+++ b/samples/helloworld-dsl/src/main/kotlin/orbit/helloworld/dsl/App.kt
@@ -33,7 +33,7 @@ fun main(args: Array<String>) {
 
     runBlocking {
         stage.start().await()
-        val greeter = stage.actorProxyFactory.createProxy<Greeter>("test")
+        val greeter = stage.actorProxyFactory.createProxy<Greeter>()
         greeter.greet("Cesar").await().forEach {
             logger.info("In ${it.key}: ${it.value.text}")
         }

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ActorKeyType.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ActorKeyType.kt
@@ -6,8 +6,10 @@
 
 package cloud.orbit.dsl.ast
 
-data class ActorDeclaration(
-    override val name: String,
-    val keyType: ActorKeyType = ActorKeyType.NO_KEY,
-    val methods: List<ActorMethod> = emptyList()
-) : Declaration
+enum class ActorKeyType {
+    NO_KEY,
+    STRING,
+    INT32,
+    INT64,
+    GUID
+}

--- a/src/dsl/orbit-dsl-java/src/test/kotlin/cloud/orbit/dsl/java/JavaCodeGeneratorTest.kt
+++ b/src/dsl/orbit-dsl-java/src/test/kotlin/cloud/orbit/dsl/java/JavaCodeGeneratorTest.kt
@@ -7,6 +7,7 @@
 package cloud.orbit.dsl.java
 
 import cloud.orbit.dsl.ast.ActorDeclaration
+import cloud.orbit.dsl.ast.ActorKeyType
 import cloud.orbit.dsl.ast.ActorMethod
 import cloud.orbit.dsl.ast.CompilationUnit
 import cloud.orbit.dsl.ast.DataDeclaration
@@ -266,7 +267,67 @@ class JavaCodeGeneratorTest {
     fun generateActor_Empty() {
         val cu = CompilationUnit(packageName, actors = listOf(ActorDeclaration("actor1")))
 
+        val expectedSource = "public interface actor1 extends cloud.orbit.core.actor.ActorWithNoKey { }"
+
+        assertOneElement(generateSource_minimalPipeline(cu)).run {
+            Assertions.assertEquals(this@JavaCodeGeneratorTest.packageName, this.packageName)
+            assertSourceMatch(expectedSource, this.toString())
+        }
+    }
+
+    @Test
+    fun generatorActor_NoKeyType() {
+        val cu = CompilationUnit(packageName, actors = listOf(ActorDeclaration("actor1")))
+
+        val expectedSource = "public interface actor1 extends cloud.orbit.core.actor.ActorWithNoKey { }"
+
+        assertOneElement(generateSource_minimalPipeline(cu)).run {
+            Assertions.assertEquals(this@JavaCodeGeneratorTest.packageName, this.packageName)
+            assertSourceMatch(expectedSource, this.toString())
+        }
+    }
+
+    @Test
+    fun generatorActor_StringKey() {
+        val cu = CompilationUnit(packageName, actors = listOf(ActorDeclaration("actor1", ActorKeyType.STRING)))
+
         val expectedSource = "public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey { }"
+
+        assertOneElement(generateSource_minimalPipeline(cu)).run {
+            Assertions.assertEquals(this@JavaCodeGeneratorTest.packageName, this.packageName)
+            assertSourceMatch(expectedSource, this.toString())
+        }
+    }
+
+    @Test
+    fun generatorActor_Int32Key() {
+        val cu = CompilationUnit(packageName, actors = listOf(ActorDeclaration("actor1", ActorKeyType.INT32)))
+
+        val expectedSource = "public interface actor1 extends cloud.orbit.core.actor.ActorWithInt32Key { }"
+
+        assertOneElement(generateSource_minimalPipeline(cu)).run {
+            Assertions.assertEquals(this@JavaCodeGeneratorTest.packageName, this.packageName)
+            assertSourceMatch(expectedSource, this.toString())
+        }
+    }
+
+    @Test
+    fun generatorActor_Int64Key() {
+        val cu = CompilationUnit(packageName, actors = listOf(ActorDeclaration("actor1", ActorKeyType.INT64)))
+
+        val expectedSource = "public interface actor1 extends cloud.orbit.core.actor.ActorWithInt64Key { }"
+
+        assertOneElement(generateSource_minimalPipeline(cu)).run {
+            Assertions.assertEquals(this@JavaCodeGeneratorTest.packageName, this.packageName)
+            assertSourceMatch(expectedSource, this.toString())
+        }
+    }
+
+    @Test
+    fun generatorActor_GuidKey() {
+        val cu = CompilationUnit(packageName, actors = listOf(ActorDeclaration("actor1", ActorKeyType.GUID)))
+
+        val expectedSource = "public interface actor1 extends cloud.orbit.core.actor.ActorWithGuidKey { }"
 
         assertOneElement(generateSource_minimalPipeline(cu)).run {
             Assertions.assertEquals(this@JavaCodeGeneratorTest.packageName, this.packageName)
@@ -278,12 +339,12 @@ class JavaCodeGeneratorTest {
     fun generateActor_SingleMethod() {
         val cu = CompilationUnit(
             packageName, actors = listOf(
-                ActorDeclaration("actor1", listOf(ActorMethod("method1", Type("string"))))
+                ActorDeclaration("actor1", methods = listOf(ActorMethod("method1", Type("string"))))
             )
         )
 
         val expectedSource = """
-            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithNoKey  {
                 java.util.concurrent.CompletableFuture<java.lang.String> method1();
             }
         """
@@ -299,7 +360,8 @@ class JavaCodeGeneratorTest {
         val cu = CompilationUnit(
             packageName, actors = listOf(
                 ActorDeclaration(
-                    "actor1", listOf(
+                    "actor1",
+                    methods = listOf(
                         ActorMethod("method1", Type("string")),
                         ActorMethod("method2", Type("string"))
                     )
@@ -308,7 +370,7 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithNoKey  {
                 java.util.concurrent.CompletableFuture<java.lang.String> method1();
                 java.util.concurrent.CompletableFuture<java.lang.String> method2();
             }
@@ -325,7 +387,8 @@ class JavaCodeGeneratorTest {
         val cu = CompilationUnit(
             packageName, actors = listOf(
                 ActorDeclaration(
-                    "actor1", listOf(
+                    "actor1",
+                    methods = listOf(
                         ActorMethod(
                             "method1",
                             Type("string"),
@@ -337,7 +400,7 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithNoKey  {
                 java.util.concurrent.CompletableFuture<java.lang.String> method1(int p1);
             }
         """
@@ -353,7 +416,8 @@ class JavaCodeGeneratorTest {
         val cu = CompilationUnit(
             packageName, actors = listOf(
                 ActorDeclaration(
-                    "actor1", listOf(
+                    "actor1",
+                    methods = listOf(
                         ActorMethod(
                             "method1",
                             Type("string"),
@@ -368,7 +432,7 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithNoKey  {
                 java.util.concurrent.CompletableFuture<java.lang.String> method1(int p1, int p2);
             }
         """
@@ -384,7 +448,8 @@ class JavaCodeGeneratorTest {
         val cu = CompilationUnit(
             packageName, actors = listOf(
                 ActorDeclaration(
-                    "actor1", listOf(
+                    "actor1",
+                    methods = listOf(
                         ActorMethod(
                             "method1",
                             Type("int32"),
@@ -396,7 +461,7 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithNoKey  {
                 java.util.concurrent.CompletableFuture<java.lang.Integer> method1(int p1);
             }
         """
@@ -413,7 +478,8 @@ class JavaCodeGeneratorTest {
             packageName,
             actors = listOf(
                 ActorDeclaration(
-                    "actor1", listOf(
+                    "actor1",
+                    methods = listOf(
                         ActorMethod(
                             "method1",
                             Type(
@@ -434,8 +500,9 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
-                java.util.concurrent.CompletableFuture<java.util.Map<java.lang.String, java.util.List<java.util.List<java.lang.Long>>>> method1();
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithNoKey  {
+                java.util.concurrent.CompletableFuture<
+                    java.util.Map<java.lang.String, java.util.List<java.util.List<java.lang.Long>>>> method1();
             }
         """
 
@@ -470,7 +537,8 @@ class JavaCodeGeneratorTest {
             ),
             actors = listOf(
                 ActorDeclaration(
-                    "actor1", listOf(
+                    "actor1",
+                    methods = listOf(
                         ActorMethod(
                             "method1",
                             Type("map", of = listOf(Type("enum1"), Type("data1"))),
@@ -502,7 +570,7 @@ class JavaCodeGeneratorTest {
             }
             """,
             """
-            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithNoKey  {
                 java.util.concurrent.CompletableFuture<java.util.Map<$packageName.enum1, $packageName.data1>> method1();
             }
             """
@@ -520,7 +588,8 @@ class JavaCodeGeneratorTest {
             packageName,
             actors = listOf(
                 ActorDeclaration(
-                    "actor1", listOf(
+                    "actor1",
+                    methods = listOf(
                         ActorMethod(
                             "method1",
                             Type("int32"),
@@ -545,7 +614,7 @@ class JavaCodeGeneratorTest {
         )
 
         val expectedSource = """
-            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithNoKey  {
                 java.util.concurrent.CompletableFuture<java.lang.Integer> method1(java.util.Map<java.lang.String, java.util.List<java.util.List<java.lang.Long>>> arg1);
             }
         """
@@ -581,7 +650,8 @@ class JavaCodeGeneratorTest {
             ),
             actors = listOf(
                 ActorDeclaration(
-                    "actor1", listOf(
+                    "actor1",
+                    methods = listOf(
                         ActorMethod(
                             "method1",
                             Type("int32"),
@@ -620,7 +690,7 @@ class JavaCodeGeneratorTest {
             }
             """,
             """
-            public interface actor1 extends cloud.orbit.core.actor.ActorWithStringKey  {
+            public interface actor1 extends cloud.orbit.core.actor.ActorWithNoKey  {
                 java.util.concurrent.CompletableFuture<java.lang.Integer> method1(java.util.Map<$packageName.enum1, $packageName.data1> arg1);
             }
             """

--- a/src/dsl/orbit-dsl-parsing/src/main/antlr/cloud/orbit/dsl/OrbitDsl.g4
+++ b/src/dsl/orbit-dsl-parsing/src/main/antlr/cloud/orbit/dsl/OrbitDsl.g4
@@ -17,10 +17,10 @@ file: declaration+ EOF ;
 declaration: enumDeclaration | actorDeclaration | dataDeclaration ;
 
 enumDeclaration: ENUM name=ID LC_BRACE members=enumMember* RC_BRACE ;
-enumMember: name=ID EQUAL index=INT SEMI_COLON;
+enumMember: name=ID EQUAL index=INT SEMI_COLON ;
 
-actorDeclaration: ACTOR name=ID LC_BRACE methods=actorMethod* RC_BRACE ;
-actorMethod: returnType=type name=ID L_PAREN (args=methodParam (COMMA args=methodParam)*)? R_PAREN SEMI_COLON;
+actorDeclaration: ACTOR name=ID (L_ANGLE keyType=type R_ANGLE)? LC_BRACE methods=actorMethod* RC_BRACE ;
+actorMethod: returnType=type name=ID L_PAREN (args=methodParam (COMMA args=methodParam)*)? R_PAREN SEMI_COLON ;
 methodParam: type name=ID ;
 
 dataDeclaration: DATA name=ID LC_BRACE fields=dataField* RC_BRACE ;

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/OrbitDslFileParser.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/OrbitDslFileParser.kt
@@ -7,6 +7,7 @@
 package cloud.orbit.dsl
 
 import cloud.orbit.dsl.ast.ActorDeclaration
+import cloud.orbit.dsl.ast.ActorKeyType
 import cloud.orbit.dsl.ast.ActorMethod
 import cloud.orbit.dsl.ast.CompilationUnit
 import cloud.orbit.dsl.ast.DataDeclaration
@@ -66,6 +67,7 @@ class OrbitDslFileParser : OrbitDslBaseVisitor<Any>() {
     override fun visitActorDeclaration(ctx: OrbitDslParser.ActorDeclarationContext?) = actors.add(
         ActorDeclaration(
             ctx!!.name.text,
+            ctx.keyType?.toActorKeyType() ?: ActorKeyType.NO_KEY,
             ctx.children
                 .asSequence()
                 .filterIsInstance(OrbitDslParser.ActorMethodContext::class.java)
@@ -89,4 +91,15 @@ class OrbitDslFileParser : OrbitDslBaseVisitor<Any>() {
                 .map(::makeType)
                 .toList()
         )
+
+    private fun OrbitDslParser.TypeContext.toActorKeyType() =
+        when (this.text) {
+            "string" -> ActorKeyType.STRING
+            "int32" -> ActorKeyType.INT32
+            "int64" -> ActorKeyType.INT64
+            "guid" -> ActorKeyType.GUID
+            else -> throw OrbitDslException(
+                "Actor key type must be string, int32, int64, or guid; found '${this.text}'"
+            )
+        }
 }

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/OrbitDslFileParserTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/OrbitDslFileParserTest.kt
@@ -7,6 +7,7 @@
 package cloud.orbit.dsl
 
 import cloud.orbit.dsl.ast.ActorDeclaration
+import cloud.orbit.dsl.ast.ActorKeyType
 import cloud.orbit.dsl.ast.ActorMethod
 import cloud.orbit.dsl.ast.CompilationUnit
 import cloud.orbit.dsl.ast.DataDeclaration
@@ -291,12 +292,96 @@ class OrbitDslFileParserTest {
     }
 
     @Test
+    fun parseActor_NoKeyType() {
+        val text = "actor foo {}"
+
+        val expectedCu = CompilationUnit(
+            packageName,
+            actors = listOf(ActorDeclaration("foo", ActorKeyType.NO_KEY))
+        )
+
+        val actualCu = OrbitDslFileParser().parse(text, packageName)
+
+        Assertions.assertEquals(expectedCu, actualCu)
+    }
+
+    @Test
+    fun parseActor_StringKey() {
+        val text = "actor foo<string> {}"
+
+        val expectedCu = CompilationUnit(
+            packageName,
+            actors = listOf(ActorDeclaration("foo", ActorKeyType.STRING))
+        )
+
+        val actualCu = OrbitDslFileParser().parse(text, packageName)
+
+        Assertions.assertEquals(expectedCu, actualCu)
+    }
+
+    @Test
+    fun parseActor_Int32Key() {
+        val text = "actor foo<int32> {}"
+
+        val expectedCu = CompilationUnit(
+            packageName,
+            actors = listOf(ActorDeclaration("foo", ActorKeyType.INT32))
+        )
+
+        val actualCu = OrbitDslFileParser().parse(text, packageName)
+
+        Assertions.assertEquals(expectedCu, actualCu)
+    }
+
+    @Test
+    fun parseActor_Int64Key() {
+        val text = "actor foo<int64> {}"
+
+        val expectedCu = CompilationUnit(
+            packageName,
+            actors = listOf(ActorDeclaration("foo", ActorKeyType.INT64))
+        )
+
+        val actualCu = OrbitDslFileParser().parse(text, packageName)
+
+        Assertions.assertEquals(expectedCu, actualCu)
+    }
+
+    @Test
+    fun parseActor_GuidKey() {
+        val text = "actor foo<guid> {}"
+
+        val expectedCu = CompilationUnit(
+            packageName,
+            actors = listOf(ActorDeclaration("foo", ActorKeyType.GUID))
+        )
+
+        val actualCu = OrbitDslFileParser().parse(text, packageName)
+
+        Assertions.assertEquals(expectedCu, actualCu)
+    }
+
+    @Test
+    fun parseActor_InvalidKeyType() {
+        val text = "actor foo<bar> {}"
+
+        val exception = assertThrows<OrbitDslException> {
+            OrbitDslFileParser().parse(text, packageName)
+        }
+
+        Assertions.assertEquals(
+            "Actor key type must be string, int32, int64, or guid; found 'bar'",
+            exception.message
+        )
+    }
+
+    @Test
     fun parseActor_Empty() {
         val text = "actor foo{}"
 
         val expectedCu = CompilationUnit(
             packageName,
-            actors = listOf(ActorDeclaration("foo"))
+            actors = listOf(ActorDeclaration("foo", ActorKeyType.NO_KEY))
         )
 
         val actualCu = OrbitDslFileParser().parse(text, packageName)
@@ -317,6 +402,7 @@ class OrbitDslFileParserTest {
             actors = listOf(
                 ActorDeclaration(
                     "foo",
+                    ActorKeyType.NO_KEY,
                     methods = listOf(ActorMethod("bar", Type("void")))
                 )
             )
@@ -341,6 +427,7 @@ class OrbitDslFileParserTest {
             actors = listOf(
                 ActorDeclaration(
                     "foo",
+                    ActorKeyType.NO_KEY,
                     methods = listOf(
                         ActorMethod("bar", Type("void")),
                         ActorMethod("baz", Type("void"))
@@ -367,6 +454,7 @@ class OrbitDslFileParserTest {
             actors = listOf(
                 ActorDeclaration(
                     "foo",
+                    ActorKeyType.NO_KEY,
                     methods = listOf(
                         ActorMethod(
                             "bar", Type("void"),
@@ -395,6 +483,7 @@ class OrbitDslFileParserTest {
             actors = listOf(
                 ActorDeclaration(
                     "foo",
+                    ActorKeyType.NO_KEY,
                     methods = listOf(
                         ActorMethod(
                             "bar", Type("void"),
@@ -445,6 +534,16 @@ class OrbitDslFileParserTest {
                 map<RGB, string> generic_multi(map<string, Payload> arg1);
                 list<map<string, RGB>> generics_nested(map<string, list<list<Payload>>> arg1);
             }
+
+            actor MyKeylessActor { }
+
+            actor MyStringKeyedActor<string> { }
+
+            actor MyInt32KeyedActor<int32> { }
+
+            actor MyInt64KeyedActor<int64> { }
+
+            actor MyGuidKeyedActor<guid> { }
         """.trimIndent()
 
         val expectedCu = CompilationUnit(
@@ -472,6 +571,7 @@ class OrbitDslFileParserTest {
             actors = listOf(
                 ActorDeclaration(
                     "MyActor",
+                    ActorKeyType.NO_KEY,
                     methods = listOf(
                         ActorMethod("no_args", Type("int")),
                         ActorMethod(
@@ -540,6 +640,26 @@ class OrbitDslFileParserTest {
                             )
                         )
                     )
+                ),
+                ActorDeclaration(
+                    "MyKeylessActor",
+                    ActorKeyType.NO_KEY
+                ),
+                ActorDeclaration(
+                    "MyStringKeyedActor",
+                    ActorKeyType.STRING
+                ),
+                ActorDeclaration(
+                    "MyInt32KeyedActor",
+                    ActorKeyType.INT32
+                ),
+                ActorDeclaration(
+                    "MyInt64KeyedActor",
+                    ActorKeyType.INT64
+                ),
+                ActorDeclaration(
+                    "MyGuidKeyedActor",
+                    ActorKeyType.GUID
                 )
             )
         )


### PR DESCRIPTION
DSL | Generated code
-- | --
`actor Greeter` | `public interface Greeter extends ActorWithNoKey`
`actor Greeter<string>` | `public interface Greeter extends ActorWithStringKey`
`actor Greeter<int32>` | `public interface Greeter extends ActorWithInt32Key`
`actor Greeter<int64>` | `public interface Greeter extends ActorWithInt64Key`
`actor Greeter<guid>` | `public interface Greeter extends ActorWithGuidKey`