### PR TITLE
DSL: support AST node annotations

### DIFF
--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ActorMethod.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ActorMethod.kt
@@ -10,4 +10,4 @@ data class ActorMethod(
     val name: String,
     val returnType: Type,
     val params: List<MethodParameter> = emptyList()
-) : AstNode
+) : AstNode()

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/AstAnnotation.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/AstAnnotation.kt
@@ -6,8 +6,4 @@
 
 package cloud.orbit.dsl.ast
 
-data class ActorDeclaration(
-    override val name: String,
-    val keyType: ActorKeyType = ActorKeyType.NO_KEY,
-    val methods: List<ActorMethod> = emptyList()
-) : AstNode(), Declaration
+interface AstAnnotation

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/AstNode.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/AstNode.kt
@@ -6,4 +6,21 @@
 
 package cloud.orbit.dsl.ast
 
-interface AstNode
+abstract class AstNode {
+    private val annotations = mutableMapOf<Class<*>, AstAnnotation>()
+
+    fun annotate(annotation: AstAnnotation) {
+        this.annotations[annotation.javaClass] = annotation
+    }
+
+    inline fun <reified T : AstAnnotation> getAnnotation(): T? = getAnnotation(T::class.java)
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T : AstAnnotation> getAnnotation(type: Class<T>): T? = annotations[type] as T?
+}
+
+inline fun <reified T : AstNode> T.annotated(annotation: AstAnnotation) =
+    this.also {
+        this.annotate(annotation)
+    }
+

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/AstVisitor.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/AstVisitor.kt
@@ -8,7 +8,7 @@ package cloud.orbit.dsl.ast
 
 abstract class AstVisitor {
     open fun visitCompilationUnit(cu: CompilationUnit) {
-        (cu.enums.asSequence() + cu.data.asSequence() + cu.actors.asSequence())
+        (cu.enums.asSequence<AstNode>() + cu.data.asSequence() + cu.actors.asSequence())
             .forEach { visitNode(it) }
     }
 

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/DataDeclaration.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/DataDeclaration.kt
@@ -9,4 +9,4 @@ package cloud.orbit.dsl.ast
 data class DataDeclaration(
     override val name: String,
     val fields: List<DataField> = emptyList()
-) : Declaration
+) : AstNode(), Declaration

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/DataField.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/DataField.kt
@@ -10,4 +10,4 @@ data class DataField(
     val name: String,
     val type: Type,
     val index: Int
-) : AstNode
+) : AstNode()

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/Declaration.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/Declaration.kt
@@ -6,6 +6,6 @@
 
 package cloud.orbit.dsl.ast
 
-interface Declaration : AstNode {
+interface Declaration {
     val name: String
 }

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/EnumDeclaration.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/EnumDeclaration.kt
@@ -9,4 +9,4 @@ package cloud.orbit.dsl.ast
 data class EnumDeclaration(
     override val name: String,
     val members: List<EnumMember> = emptyList()
-) : Declaration
+) : AstNode(), Declaration

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/EnumMember.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/EnumMember.kt
@@ -9,4 +9,4 @@ package cloud.orbit.dsl.ast
 data class EnumMember(
     val name: String,
     val index: Int
-) : AstNode
+) : AstNode()

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/MethodParameter.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/MethodParameter.kt
@@ -9,4 +9,4 @@ package cloud.orbit.dsl.ast
 data class MethodParameter(
     val name: String,
     val type: Type
-) : AstNode
+) : AstNode()

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/Type.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/Type.kt
@@ -9,6 +9,6 @@ package cloud.orbit.dsl.ast
 data class Type(
     val name: String,
     val of: List<Type> = emptyList()
-) : AstNode {
+) : AstNode() {
     val isGeneric = of.isNotEmpty()
 }

--- a/src/dsl/orbit-dsl-ast/src/test/kotlin/cloud/orbit/dsl/ast/AstNodeTest.kt
+++ b/src/dsl/orbit-dsl-ast/src/test/kotlin/cloud/orbit/dsl/ast/AstNodeTest.kt
@@ -1,0 +1,59 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.ast
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class AstNodeTest {
+    private class TestAnnotation : AstAnnotation
+    private class AnotherTestAnnotation : AstAnnotation
+
+    @Test
+    fun astNodeCanBeAnnotated() {
+        val astNode = object : AstNode() {}
+        val annotation = TestAnnotation()
+
+        astNode.annotate(annotation)
+
+        Assertions.assertSame(annotation, astNode.getAnnotation<TestAnnotation>())
+        Assertions.assertSame(annotation, astNode.getAnnotation(TestAnnotation::class.java))
+    }
+
+    @Test
+    fun supportsSingleAnnotationPerType() {
+        val astNode = object : AstNode() {}
+        val annotation1 = TestAnnotation()
+        val annotation2 = TestAnnotation()
+        val annotation3 = AnotherTestAnnotation()
+
+        astNode.annotate(annotation1)
+        astNode.annotate(annotation2)
+        astNode.annotate(annotation3)
+
+        Assertions.assertSame(annotation2, astNode.getAnnotation<TestAnnotation>())
+        Assertions.assertSame(annotation3, astNode.getAnnotation<AnotherTestAnnotation>())
+    }
+
+    @Test
+    fun getAnnotationReturnsNullWhenAstNodeNotAnnotatedWithType() {
+        val astNode = object : AstNode() {}
+
+        Assertions.assertNull(astNode.getAnnotation<TestAnnotation>())
+    }
+
+    @Test
+    fun annotatedReturnsSameNodeWithAnnotation() {
+        val astNode = object : AstNode() {}
+        val annotation = TestAnnotation()
+
+        val returnedNode = astNode.annotated(annotation)
+
+        Assertions.assertSame(astNode, returnedNode)
+        Assertions.assertSame(annotation, astNode.getAnnotation<TestAnnotation>())
+    }
+}


### PR DESCRIPTION
This is the first of a series of PRs I'll be opening over the next days. This one adds support to annotating AST nodes with arbitrary information.

This will allow us to annotate nodes with things like a parsing context (containing things like a node's text location in a file), so that we can emit proper error messages when working on the AST (e.g. when type checking).