### PR TITLE
DSL: annotate AST nodes with parse context

### DIFF
--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ParseContext.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ParseContext.kt
@@ -1,0 +1,9 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.ast
+
+data class ParseContext(val filePath: String, val line: Int, val column: Int) : AstAnnotation

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/DataDeclarationVisitor.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/DataDeclarationVisitor.kt
@@ -10,9 +10,11 @@ import cloud.orbit.dsl.OrbitDslBaseVisitor
 import cloud.orbit.dsl.OrbitDslParser
 import cloud.orbit.dsl.ast.DataDeclaration
 import cloud.orbit.dsl.ast.DataField
+import cloud.orbit.dsl.ast.annotated
 
 class DataDeclarationVisitor(
-    private val dataFieldTypeVisitor: TypeVisitor
+    private val dataFieldTypeVisitor: TypeVisitor,
+    private val parseContextProvider: ParseContextProvider
 ) : OrbitDslBaseVisitor<DataDeclaration>() {
     override fun visitDataDeclaration(ctx: OrbitDslParser.DataDeclarationContext?) =
         DataDeclaration(
@@ -24,7 +26,8 @@ class DataDeclarationVisitor(
                         it.name.text,
                         it.type().accept(dataFieldTypeVisitor),
                         it.index.text.toInt()
-                    )
+                    ).annotated(parseContextProvider.fromToken(it.name))
                 }
                 .toList())
+            .annotated(parseContextProvider.fromToken(ctx.name))
 }

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/EnumDeclarationVisitor.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/EnumDeclarationVisitor.kt
@@ -10,8 +10,11 @@ import cloud.orbit.dsl.OrbitDslBaseVisitor
 import cloud.orbit.dsl.OrbitDslParser
 import cloud.orbit.dsl.ast.EnumDeclaration
 import cloud.orbit.dsl.ast.EnumMember
+import cloud.orbit.dsl.ast.annotated
 
-class EnumDeclarationVisitor() : OrbitDslBaseVisitor<EnumDeclaration>() {
+class EnumDeclarationVisitor(
+    private val parseContextProvider: ParseContextProvider
+) : OrbitDslBaseVisitor<EnumDeclaration>() {
     override fun visitEnumDeclaration(ctx: OrbitDslParser.EnumDeclarationContext?) =
         EnumDeclaration(
             ctx!!.name.text,
@@ -19,6 +22,8 @@ class EnumDeclarationVisitor() : OrbitDslBaseVisitor<EnumDeclaration>() {
                 .filterIsInstance(OrbitDslParser.EnumMemberContext::class.java)
                 .map {
                     EnumMember(it.name.text, it.index.text.toInt())
+                        .annotated(parseContextProvider.fromToken(it.name))
                 }
                 .toList())
+            .annotated(parseContextProvider.fromToken(ctx.name))
 }

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/ParseContextProvider.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/ParseContextProvider.kt
@@ -1,0 +1,14 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.visitor
+
+import cloud.orbit.dsl.ast.ParseContext
+import org.antlr.v4.runtime.Token
+
+interface ParseContextProvider {
+    fun fromToken(token: Token): ParseContext
+}

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/TypeVisitor.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/TypeVisitor.kt
@@ -11,11 +11,13 @@ import cloud.orbit.dsl.OrbitDslParser
 import cloud.orbit.dsl.ast.Type
 import cloud.orbit.dsl.ast.annotated
 
-class TypeVisitor : OrbitDslBaseVisitor<Type>() {
+class TypeVisitor(
+    private val parseContextProvider: ParseContextProvider
+) : OrbitDslBaseVisitor<Type>() {
     override fun visitType(ctx: OrbitDslParser.TypeContext?) =
         Type(ctx!!.name.text, ctx.children
             .filterIsInstance(OrbitDslParser.TypeContext::class.java)
-            .map { it.accept(TypeVisitor()) }
+            .map { it.accept(TypeVisitor(parseContextProvider)) }
             .toList()
-        )
+        ).annotated(parseContextProvider.fromToken(ctx.name))
 }

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/OrbitDslFileParserTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/OrbitDslFileParserTest.kt
@@ -15,6 +15,7 @@ import cloud.orbit.dsl.ast.DataField
 import cloud.orbit.dsl.ast.EnumDeclaration
 import cloud.orbit.dsl.ast.EnumMember
 import cloud.orbit.dsl.ast.MethodParameter
+import cloud.orbit.dsl.ast.ParseContext
 import cloud.orbit.dsl.ast.Type
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -210,5 +211,86 @@ class OrbitDslFileParserTest {
         val actualCompilationUnit = OrbitDslFileParser().parse(text, testPackageName, testFilePath)
 
         assertEquals(expectedCompilationUnit, actualCompilationUnit)
+    }
+
+    @Test
+    fun parseFile_ParseContextAnnotationsAreCorrect() {
+        val text = """
+            enum
+                AnEnum {
+                    A_VALUE
+                        = 1;
+            }
+
+             data
+                SomeData {
+                    string
+                        a_field
+                            = 1;
+            }
+
+            actor
+                TheActor
+                    <
+                        string
+                    >
+            {
+                map<
+                    string,
+                        list<
+                            int32
+                            >
+                    >
+                        a_method
+                        (
+                            int32
+                                param
+                        );
+            }
+        """.trimIndent()
+
+        val compilationUnit = OrbitDslFileParser().parse(text, testPackageName, testFilePath)
+
+        assertEquals(
+            ParseContext(testFilePath, 2, 4),
+            compilationUnit.enums[0].getAnnotation<ParseContext>())
+        assertEquals(
+            ParseContext(testFilePath, 3, 8),
+            compilationUnit.enums[0].members[0].getAnnotation<ParseContext>())
+
+        assertEquals(
+            ParseContext(testFilePath, 8, 4),
+            compilationUnit.data[0].getAnnotation<ParseContext>())
+        assertEquals(
+            ParseContext(testFilePath, 9, 8),
+            compilationUnit.data[0].fields[0].type.getAnnotation<ParseContext>())
+        assertEquals(
+            ParseContext(testFilePath, 10, 12),
+            compilationUnit.data[0].fields[0].getAnnotation<ParseContext>())
+
+        assertEquals(
+            ParseContext(testFilePath, 15, 4),
+            compilationUnit.actors[0].getAnnotation<ParseContext>())
+        assertEquals(
+            ParseContext(testFilePath, 20, 4),
+            compilationUnit.actors[0].methods[0].returnType.getAnnotation<ParseContext>())
+        assertEquals(
+            ParseContext(testFilePath, 21, 8),
+            compilationUnit.actors[0].methods[0].returnType.of[0].getAnnotation<ParseContext>())
+        assertEquals(
+            ParseContext(testFilePath, 22, 12),
+            compilationUnit.actors[0].methods[0].returnType.of[1].getAnnotation<ParseContext>())
+        assertEquals(
+            ParseContext(testFilePath, 23, 16),
+            compilationUnit.actors[0].methods[0].returnType.of[1].of[0].getAnnotation<ParseContext>())
+        assertEquals(
+            ParseContext(testFilePath, 26, 12),
+            compilationUnit.actors[0].methods[0].getAnnotation<ParseContext>())
+        assertEquals(
+            ParseContext(testFilePath, 28, 16),
+            compilationUnit.actors[0].methods[0].params[0].type.getAnnotation<ParseContext>())
+        assertEquals(
+            ParseContext(testFilePath, 29, 20),
+            compilationUnit.actors[0].methods[0].params[0].getAnnotation<ParseContext>())
     }
 }

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/ActorDeclarationVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/ActorDeclarationVisitorTest.kt
@@ -11,13 +11,14 @@ import cloud.orbit.dsl.ast.ActorDeclaration
 import cloud.orbit.dsl.ast.ActorKeyType
 import cloud.orbit.dsl.ast.ActorMethod
 import cloud.orbit.dsl.ast.MethodParameter
+import cloud.orbit.dsl.ast.ParseContext
 import cloud.orbit.dsl.ast.Type
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class ActorDeclarationVisitorTest {
-    private val visitor = ActorDeclarationVisitor(TypeVisitor())
+    private val visitor = ActorDeclarationVisitor(TypeVisitor(FakeParseContextProvider), FakeParseContextProvider)
 
     @Test
     fun buildsKeylessActorDeclaration() {
@@ -105,6 +106,50 @@ class ActorDeclarationVisitorTest {
                 """,
                 OrbitDslParser::actorDeclaration
             )
+        )
+    }
+
+    @Test
+    fun annotatesActorDeclarationWithParseContext() {
+        val actorDeclaration = visitor.parse("actor actor1 { }", OrbitDslParser::actorDeclaration)
+
+        Assertions.assertEquals(
+            FakeParseContextProvider.fakeParseContext,
+            actorDeclaration.getAnnotation<ParseContext>()
+        )
+    }
+
+    @Test
+    fun annotatesActorMethodWithParseContext() {
+        val actorDeclaration = visitor.parse(
+            """
+                actor actor1 {
+                    void m();
+                }
+            """,
+            OrbitDslParser::actorDeclaration
+        )
+
+        Assertions.assertEquals(
+            FakeParseContextProvider.fakeParseContext,
+            actorDeclaration.methods[0].getAnnotation<ParseContext>()
+        )
+    }
+
+    @Test
+    fun annotatesMethodParameterWithParseContext() {
+        val actorDeclaration = visitor.parse(
+            """
+                actor actor1 {
+                    void m(int32 p);
+                }
+            """,
+            OrbitDslParser::actorDeclaration
+        )
+
+        Assertions.assertEquals(
+            FakeParseContextProvider.fakeParseContext,
+            actorDeclaration.methods[0].params[0].getAnnotation<ParseContext>()
         )
     }
 }

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/DataDeclarationVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/DataDeclarationVisitorTest.kt
@@ -9,12 +9,13 @@ package cloud.orbit.dsl.visitor
 import cloud.orbit.dsl.OrbitDslParser
 import cloud.orbit.dsl.ast.DataDeclaration
 import cloud.orbit.dsl.ast.DataField
+import cloud.orbit.dsl.ast.ParseContext
 import cloud.orbit.dsl.ast.Type
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class DataDeclarationVisitorTest {
-    private val visitor = DataDeclarationVisitor(TypeVisitor())
+    private val visitor = DataDeclarationVisitor(TypeVisitor(FakeParseContextProvider), FakeParseContextProvider)
 
     @Test
     fun buildsDataDeclaration() {
@@ -43,6 +44,33 @@ class DataDeclarationVisitorTest {
                 """,
                 OrbitDslParser::dataDeclaration
             )
+        )
+    }
+
+    @Test
+    fun annotatesDataDeclarationWithParseContext() {
+        val dataDeclaration = visitor.parse("data data1 {}", OrbitDslParser::dataDeclaration)
+
+        Assertions.assertEquals(
+            FakeParseContextProvider.fakeParseContext,
+            dataDeclaration.getAnnotation<ParseContext>()
+        )
+    }
+
+    @Test
+    fun annotatesDataFieldWithParseContext() {
+        val dataDeclaration = visitor.parse(
+            """
+                data data1 {
+                    int32 field = 1;
+                }
+                """,
+            OrbitDslParser::dataDeclaration
+        )
+
+        Assertions.assertEquals(
+            FakeParseContextProvider.fakeParseContext,
+            dataDeclaration.fields[0].getAnnotation<ParseContext>()
         )
     }
 }

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/EnumDeclarationVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/EnumDeclarationVisitorTest.kt
@@ -9,11 +9,12 @@ package cloud.orbit.dsl.visitor
 import cloud.orbit.dsl.OrbitDslParser
 import cloud.orbit.dsl.ast.EnumDeclaration
 import cloud.orbit.dsl.ast.EnumMember
+import cloud.orbit.dsl.ast.ParseContext
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class EnumDeclarationVisitorTest {
-    private val visitor = EnumDeclarationVisitor()
+    private val visitor = EnumDeclarationVisitor(FakeParseContextProvider)
 
     @Test
     fun buildsEnumDeclaration() {
@@ -40,6 +41,33 @@ class EnumDeclarationVisitorTest {
                 """,
                 OrbitDslParser::enumDeclaration
             )
+        )
+    }
+
+    @Test
+    fun annotatesEnumDeclarationWithParseContext() {
+        val enumDeclaration = visitor.parse("enum enum1 { }", OrbitDslParser::enumDeclaration)
+
+        Assertions.assertEquals(
+            FakeParseContextProvider.fakeParseContext,
+            enumDeclaration.getAnnotation<ParseContext>()
+        )
+    }
+
+    @Test
+    fun annotatesEnumMemberWithParseContext() {
+        val enumDeclaration = visitor.parse(
+            """
+            enum enum1 {
+                MEMBER = 1;
+            }
+            """,
+            OrbitDslParser::enumDeclaration
+        )
+
+        Assertions.assertEquals(
+            FakeParseContextProvider.fakeParseContext,
+            enumDeclaration.members[0].getAnnotation<ParseContext>()
         )
     }
 }

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/FakeParseContextProvider.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/FakeParseContextProvider.kt
@@ -1,0 +1,16 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.visitor
+
+import cloud.orbit.dsl.ast.ParseContext
+import org.antlr.v4.runtime.Token
+
+object FakeParseContextProvider : ParseContextProvider {
+    val fakeParseContext = ParseContext("", 0, 0)
+
+    override fun fromToken(token: Token): ParseContext = fakeParseContext
+}

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/TypeVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/TypeVisitorTest.kt
@@ -7,12 +7,13 @@
 package cloud.orbit.dsl.visitor
 
 import cloud.orbit.dsl.OrbitDslParser
+import cloud.orbit.dsl.ast.ParseContext
 import cloud.orbit.dsl.ast.Type
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class TypeVisitorTest {
-    private val visitor = TypeVisitor()
+    private val visitor = TypeVisitor(FakeParseContextProvider)
 
     @Test
     fun buildsSimpleType() {
@@ -40,5 +41,12 @@ class TypeVisitorTest {
             ),
             visitor.parse("map<string, list<int32>>", OrbitDslParser::type)
         )
+    }
+
+    @Test
+    fun annotatesTypeWithParseContext() {
+        Assertions.assertEquals(
+            FakeParseContextProvider.fakeParseContext,
+            visitor.parse("int32", OrbitDslParser::type).getAnnotation<ParseContext>())
     }
 }


### PR DESCRIPTION
When building the AST, annotate each node with its source file path and text position. This will allow us to emit error messages with contextual information when processing the AST.