### PR TITLE
DSL: annotate AST type nodes with occurrence context

### DIFF
--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/TypeOccurrenceContext.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/TypeOccurrenceContext.kt
@@ -1,0 +1,14 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.ast
+
+enum class TypeOccurrenceContext : AstAnnotation {
+    DATA_FIELD,
+    METHOD_PARAMETER,
+    METHOD_RETURN,
+    TYPE_PARAMETER
+}

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/OrbitDslFileParser.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/OrbitDslFileParser.kt
@@ -8,6 +8,7 @@ package cloud.orbit.dsl
 
 import cloud.orbit.dsl.ast.CompilationUnit
 import cloud.orbit.dsl.ast.ParseContext
+import cloud.orbit.dsl.ast.TypeOccurrenceContext
 import cloud.orbit.dsl.visitor.ActorDeclarationVisitor
 import cloud.orbit.dsl.visitor.CompilationUnitBuilderVisitor
 import cloud.orbit.dsl.visitor.DataDeclarationVisitor
@@ -66,10 +67,17 @@ class OrbitDslFileParser {
                 ParseContext(filePath, token.line, token.charPositionInLine)
         }
 
-        val typeVisitor = TypeVisitor(parseContextProvider)
+        val typeParameterVisitor = TypeVisitor(TypeOccurrenceContext.TYPE_PARAMETER, parseContextProvider)
         val enumDeclarationVisitor = EnumDeclarationVisitor(parseContextProvider)
-        val dataDeclarationVisitor = DataDeclarationVisitor(typeVisitor, parseContextProvider)
-        val actorDeclarationVisitor = ActorDeclarationVisitor(typeVisitor, parseContextProvider)
+        val dataDeclarationVisitor = DataDeclarationVisitor(
+            TypeVisitor(TypeOccurrenceContext.DATA_FIELD, typeParameterVisitor, parseContextProvider),
+            parseContextProvider
+        )
+        val actorDeclarationVisitor = ActorDeclarationVisitor(
+            TypeVisitor(TypeOccurrenceContext.METHOD_RETURN, typeParameterVisitor, parseContextProvider),
+            TypeVisitor(TypeOccurrenceContext.METHOD_PARAMETER, typeParameterVisitor, parseContextProvider),
+            parseContextProvider
+        )
 
         try {
             return CompilationUnitBuilderVisitor(

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/ActorDeclarationVisitor.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/ActorDeclarationVisitor.kt
@@ -16,7 +16,8 @@ import cloud.orbit.dsl.ast.MethodParameter
 import cloud.orbit.dsl.ast.annotated
 
 class ActorDeclarationVisitor(
-    private val typeVisitor: TypeVisitor,
+    private val methodReturnTypeVisitor: TypeVisitor,
+    private val methodParameterTypeVisitor: TypeVisitor,
     private val parseContextProvider: ParseContextProvider
 ) : OrbitDslBaseVisitor<ActorDeclaration>() {
     override fun visitActorDeclaration(ctx: OrbitDslParser.ActorDeclarationContext?) =
@@ -28,11 +29,11 @@ class ActorDeclarationVisitor(
                 .map { m ->
                     ActorMethod(
                         name = m.name.text,
-                        returnType = m.returnType.accept(typeVisitor),
+                        returnType = m.returnType.accept(methodReturnTypeVisitor),
                         params = m.children
                             .filterIsInstance(OrbitDslParser.MethodParamContext::class.java)
                             .map { p ->
-                                MethodParameter(p.name.text, p.type().accept(typeVisitor))
+                                MethodParameter(p.name.text, p.type().accept(methodParameterTypeVisitor))
                                     .annotated(parseContextProvider.fromToken(p.name))
                             }
                             .toList())

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/TypeVisitor.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/TypeVisitor.kt
@@ -9,15 +9,24 @@ package cloud.orbit.dsl.visitor
 import cloud.orbit.dsl.OrbitDslBaseVisitor
 import cloud.orbit.dsl.OrbitDslParser
 import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeOccurrenceContext
 import cloud.orbit.dsl.ast.annotated
 
 class TypeVisitor(
+    private val typeOccurrenceContext: TypeOccurrenceContext,
+    private val typeParameterVisitor: TypeVisitor?,
     private val parseContextProvider: ParseContextProvider
 ) : OrbitDslBaseVisitor<Type>() {
+    constructor(typeOccurrenceContext: TypeOccurrenceContext,
+                parseContextProvider: ParseContextProvider) :
+        this(typeOccurrenceContext, null, parseContextProvider)
+
     override fun visitType(ctx: OrbitDslParser.TypeContext?) =
         Type(ctx!!.name.text, ctx.children
             .filterIsInstance(OrbitDslParser.TypeContext::class.java)
-            .map { it.accept(TypeVisitor(parseContextProvider)) }
+            .map { it.accept(typeParameterVisitor ?: this) }
             .toList()
-        ).annotated(parseContextProvider.fromToken(ctx.name))
+        )
+            .annotated(parseContextProvider.fromToken(ctx.name))
+            .annotated(typeOccurrenceContext)
 }

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/OrbitDslFileParserTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/OrbitDslFileParserTest.kt
@@ -17,6 +17,7 @@ import cloud.orbit.dsl.ast.EnumMember
 import cloud.orbit.dsl.ast.MethodParameter
 import cloud.orbit.dsl.ast.ParseContext
 import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeOccurrenceContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -253,44 +254,108 @@ class OrbitDslFileParserTest {
 
         assertEquals(
             ParseContext(testFilePath, 2, 4),
-            compilationUnit.enums[0].getAnnotation<ParseContext>())
+            compilationUnit.enums[0].getAnnotation<ParseContext>()
+        )
         assertEquals(
             ParseContext(testFilePath, 3, 8),
-            compilationUnit.enums[0].members[0].getAnnotation<ParseContext>())
+            compilationUnit.enums[0].members[0].getAnnotation<ParseContext>()
+        )
 
         assertEquals(
             ParseContext(testFilePath, 8, 4),
-            compilationUnit.data[0].getAnnotation<ParseContext>())
+            compilationUnit.data[0].getAnnotation<ParseContext>()
+        )
         assertEquals(
             ParseContext(testFilePath, 9, 8),
-            compilationUnit.data[0].fields[0].type.getAnnotation<ParseContext>())
+            compilationUnit.data[0].fields[0].type.getAnnotation<ParseContext>()
+        )
         assertEquals(
             ParseContext(testFilePath, 10, 12),
-            compilationUnit.data[0].fields[0].getAnnotation<ParseContext>())
+            compilationUnit.data[0].fields[0].getAnnotation<ParseContext>()
+        )
 
         assertEquals(
             ParseContext(testFilePath, 15, 4),
-            compilationUnit.actors[0].getAnnotation<ParseContext>())
+            compilationUnit.actors[0].getAnnotation<ParseContext>()
+        )
         assertEquals(
             ParseContext(testFilePath, 20, 4),
-            compilationUnit.actors[0].methods[0].returnType.getAnnotation<ParseContext>())
+            compilationUnit.actors[0].methods[0].returnType.getAnnotation<ParseContext>()
+        )
         assertEquals(
             ParseContext(testFilePath, 21, 8),
-            compilationUnit.actors[0].methods[0].returnType.of[0].getAnnotation<ParseContext>())
+            compilationUnit.actors[0].methods[0].returnType.of[0].getAnnotation<ParseContext>()
+        )
         assertEquals(
             ParseContext(testFilePath, 22, 12),
-            compilationUnit.actors[0].methods[0].returnType.of[1].getAnnotation<ParseContext>())
+            compilationUnit.actors[0].methods[0].returnType.of[1].getAnnotation<ParseContext>()
+        )
         assertEquals(
             ParseContext(testFilePath, 23, 16),
-            compilationUnit.actors[0].methods[0].returnType.of[1].of[0].getAnnotation<ParseContext>())
+            compilationUnit.actors[0].methods[0].returnType.of[1].of[0].getAnnotation<ParseContext>()
+        )
         assertEquals(
             ParseContext(testFilePath, 26, 12),
-            compilationUnit.actors[0].methods[0].getAnnotation<ParseContext>())
+            compilationUnit.actors[0].methods[0].getAnnotation<ParseContext>()
+        )
         assertEquals(
             ParseContext(testFilePath, 28, 16),
-            compilationUnit.actors[0].methods[0].params[0].type.getAnnotation<ParseContext>())
+            compilationUnit.actors[0].methods[0].params[0].type.getAnnotation<ParseContext>()
+        )
         assertEquals(
             ParseContext(testFilePath, 29, 20),
-            compilationUnit.actors[0].methods[0].params[0].getAnnotation<ParseContext>())
+            compilationUnit.actors[0].methods[0].params[0].getAnnotation<ParseContext>()
+        )
+    }
+
+    @Test
+    fun parseFile_TypeOccurrenceContextAnnotationsAreCorrect() {
+        val text = """
+            data SomeData {
+                string a_field = 1;
+            }
+             actor TheActor<string> {
+                map<string, list<int32>> a_method(map<string, list<int32>> param);
+            }
+        """.trimIndent()
+
+        val compilationUnit = OrbitDslFileParser().parse(text, testPackageName, testFilePath)
+
+        assertEquals(
+            TypeOccurrenceContext.DATA_FIELD,
+            compilationUnit.data[0].fields[0].type.getAnnotation<TypeOccurrenceContext>()
+        )
+        assertEquals(
+            TypeOccurrenceContext.METHOD_RETURN,
+            compilationUnit.actors[0].methods[0].returnType.getAnnotation<TypeOccurrenceContext>()
+        )
+        assertEquals(
+            TypeOccurrenceContext.TYPE_PARAMETER,
+            compilationUnit.actors[0].methods[0].returnType.of[0].getAnnotation<TypeOccurrenceContext>()
+        )
+        assertEquals(
+            TypeOccurrenceContext.TYPE_PARAMETER,
+            compilationUnit.actors[0].methods[0].returnType.of[1].getAnnotation<TypeOccurrenceContext>()
+        )
+        assertEquals(
+            TypeOccurrenceContext.TYPE_PARAMETER,
+            compilationUnit.actors[0].methods[0].returnType.of[1].of[0].getAnnotation<TypeOccurrenceContext>()
+        )
+        assertEquals(
+            TypeOccurrenceContext.METHOD_PARAMETER,
+            compilationUnit.actors[0].methods[0].params[0].type.getAnnotation<TypeOccurrenceContext>()
+        )
+        assertEquals(
+            TypeOccurrenceContext.TYPE_PARAMETER,
+            compilationUnit.actors[0].methods[0].params[0].type.of[0].getAnnotation<TypeOccurrenceContext>()
+        )
+        assertEquals(
+            TypeOccurrenceContext.TYPE_PARAMETER,
+            compilationUnit.actors[0].methods[0].params[0].type.of[1].getAnnotation<TypeOccurrenceContext>()
+        )
+        assertEquals(
+            TypeOccurrenceContext.TYPE_PARAMETER,
+            compilationUnit.actors[0].methods[0].params[0].type.of[1].of[0].getAnnotation<TypeOccurrenceContext>()
+        )
     }
 }

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/ActorDeclarationVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/ActorDeclarationVisitorTest.kt
@@ -13,12 +13,16 @@ import cloud.orbit.dsl.ast.ActorMethod
 import cloud.orbit.dsl.ast.MethodParameter
 import cloud.orbit.dsl.ast.ParseContext
 import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeOccurrenceContext
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class ActorDeclarationVisitorTest {
-    private val visitor = ActorDeclarationVisitor(TypeVisitor(FakeParseContextProvider), FakeParseContextProvider)
+    private val visitor = ActorDeclarationVisitor(
+        TypeVisitor(TypeOccurrenceContext.METHOD_RETURN, FakeParseContextProvider),
+        TypeVisitor(TypeOccurrenceContext.METHOD_PARAMETER, FakeParseContextProvider),
+        FakeParseContextProvider)
 
     @Test
     fun buildsKeylessActorDeclaration() {

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/DataDeclarationVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/DataDeclarationVisitorTest.kt
@@ -11,11 +11,14 @@ import cloud.orbit.dsl.ast.DataDeclaration
 import cloud.orbit.dsl.ast.DataField
 import cloud.orbit.dsl.ast.ParseContext
 import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeOccurrenceContext
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class DataDeclarationVisitorTest {
-    private val visitor = DataDeclarationVisitor(TypeVisitor(FakeParseContextProvider), FakeParseContextProvider)
+    private val visitor = DataDeclarationVisitor(
+        TypeVisitor(TypeOccurrenceContext.DATA_FIELD, FakeParseContextProvider),
+        FakeParseContextProvider)
 
     @Test
     fun buildsDataDeclaration() {

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/TypeVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/TypeVisitorTest.kt
@@ -9,11 +9,17 @@ package cloud.orbit.dsl.visitor
 import cloud.orbit.dsl.OrbitDslParser
 import cloud.orbit.dsl.ast.ParseContext
 import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeOccurrenceContext
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class TypeVisitorTest {
-    private val visitor = TypeVisitor(FakeParseContextProvider)
+    private val typeOccurrenceContext = TypeOccurrenceContext.values().random()
+    private val visitor = TypeVisitor(
+        typeOccurrenceContext,
+        TypeVisitor(TypeOccurrenceContext.TYPE_PARAMETER, FakeParseContextProvider),
+        FakeParseContextProvider
+    )
 
     @Test
     fun buildsSimpleType() {
@@ -47,6 +53,23 @@ class TypeVisitorTest {
     fun annotatesTypeWithParseContext() {
         Assertions.assertEquals(
             FakeParseContextProvider.fakeParseContext,
-            visitor.parse("int32", OrbitDslParser::type).getAnnotation<ParseContext>())
+            visitor.parse("int32", OrbitDslParser::type).getAnnotation<ParseContext>()
+        )
+    }
+
+    @Test
+    fun annotatesTypeWithTypeOccurrenceContext() {
+        Assertions.assertEquals(
+            typeOccurrenceContext,
+            visitor.parse("int32", OrbitDslParser::type).getAnnotation<TypeOccurrenceContext>()
+        )
+    }
+
+    @Test
+    fun annotatesTypeParameterWithTypeOccurrenceContext() {
+        Assertions.assertEquals(
+            TypeOccurrenceContext.TYPE_PARAMETER,
+            visitor.parse("list<int32>", OrbitDslParser::type).of[0].getAnnotation<TypeOccurrenceContext>()
+        )
     }
 }


### PR DESCRIPTION
Annotate each type AST node with where it occurs: a data field, a method parameter, etc.

This enables writing type checks like "void can only appear in method return."