### PR TITLE
DSL: parse mutiple files in OrbitDslFileParser

### DIFF
--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/OrbitDslParseInput.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/OrbitDslParseInput.kt
@@ -1,0 +1,13 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+/**
+ * @param text a string containing Orbit DSL source code.
+ * @param packageName the package name the resulting [CompilationUnit] will be associated with.
+ * @param filePath the filesystem path that syntax errors and syntax tree annotations will be associated with.
+ */
+data class OrbitDslParseInput(val text: String, val packageName: String, val filePath: String)

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/OrbitDslParseInput.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/OrbitDslParseInput.kt
@@ -6,8 +6,10 @@
 
 package cloud.orbit.dsl
 /**
+ * Represents an input to [OrbitDslFileParser].
+ *
  * @param text a string containing Orbit DSL source code.
- * @param packageName the package name the resulting [CompilationUnit] will be associated with.
- * @param filePath the filesystem path that syntax errors and syntax tree annotations will be associated with.
+ * @param packageName the fully qualified name of the package containing this input.
+ * @param filePath the filesystem path where this input resides.
  */
 data class OrbitDslParseInput(val text: String, val packageName: String, val filePath: String)

--- a/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslException.kt
+++ b/src/plugins/orbit-gradle-plugin/src/main/kotlin/cloud/orbit/plugin/gradle/OrbitDslException.kt
@@ -1,9 +1,0 @@
-/*
- Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
- This file is part of the Orbit Project <https://www.orbit.cloud>.
- See license in LICENSE.
- */
-
-package cloud.orbit.plugin.gradle
-
-class OrbitDslException(message: String) : RuntimeException(message)


### PR DESCRIPTION
Move multi-file parsing logic from the Gradle plugin to `OrbitDslFileParser`.

For now we don't do anything that requires looking at a collection of `CompilationUnit`s, but when we start doing type checks we'll have to. The long term idea here is to make `OrbitDslFileParser` the main unit that takes input sources, parses them, type checks them, and returns a collection of units that are ready for code generation. This will be useful when we start generating code in more than one language.