### PR TITLE
DSL: add type checking infrastructure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ configureProject(":src:framework:orbit-runtime", [withKotlin, withJava, withTest
 configureProject(":src:dsl:orbit-dsl-ast", [withKotlin, withTests, publish])
 configureProject(":src:dsl:orbit-dsl-java", [withKotlin, withTests, publish])
 configureProject(":src:dsl:orbit-dsl-parsing", [withKotlin, withJava, withTests, publish])
+configureProject(":src:dsl:orbit-dsl-typecheck", [withKotlin, withTests, publish])
 
 // Plugins
 configureProject(":src:plugins:orbit-gradle-plugin", [withKotlin, withTests, localPublish])

--- a/samples/helloworld-dsl-java/build.gradle
+++ b/samples/helloworld-dsl-java/build.gradle
@@ -24,6 +24,10 @@ buildscript {
         }
 
         maven {
+            url "$projectDir/../../src/dsl/orbit-dsl-typecheck/build/repo"
+        }
+
+        maven {
             url "$projectDir/../../src/plugins/orbit-gradle-plugin/build/repo"
         }
 

--- a/samples/helloworld-dsl/build.gradle
+++ b/samples/helloworld-dsl/build.gradle
@@ -26,6 +26,10 @@ buildscript {
         }
 
         maven {
+            url "$projectDir/../../src/dsl/orbit-dsl-typecheck/build/repo"
+        }
+
+        maven {
             url "$projectDir/../../src/plugins/orbit-gradle-plugin/build/repo"
         }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,8 @@ include(
 include(
         ":src:dsl:orbit-dsl-ast",
         ":src:dsl:orbit-dsl-java",
-        ":src:dsl:orbit-dsl-parsing"
+        ":src:dsl:orbit-dsl-parsing",
+        ":src:dsl:orbit-dsl-typecheck"
 )
 
 include(

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/AstVisitor.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/AstVisitor.kt
@@ -10,8 +10,9 @@ abstract class AstVisitor {
     private val errorListeners = mutableSetOf<ErrorListener>()
 
     open fun visitCompilationUnit(cu: CompilationUnit) {
-        (cu.enums.asSequence<AstNode>() + cu.data.asSequence() + cu.actors.asSequence())
-            .forEach { visitNode(it) }
+        cu.enums.forEach { visitNode(it) }
+        cu.data.forEach { visitNode(it) }
+        cu.actors.forEach { visitNode(it) }
     }
 
     open fun visitNode(node: AstNode) {
@@ -20,6 +21,8 @@ abstract class AstVisitor {
             is EnumMember -> visitEnumMember(node)
             is DataField -> visitDataField(node)
             is ActorMethod -> visitActorMethod(node)
+            is MethodParameter -> visitMethodParameter(node)
+            is Type -> visitType(node)
         }
     }
 
@@ -43,6 +46,7 @@ abstract class AstVisitor {
     }
 
     open fun visitDataField(field: DataField) {
+        visitNode(field.type)
     }
 
     open fun visitActorDeclaration(actor: ActorDeclaration) {
@@ -50,13 +54,23 @@ abstract class AstVisitor {
     }
 
     open fun visitActorMethod(method: ActorMethod) {
+        visitNode(method.returnType)
+        method.params.forEach { visitNode(it) }
     }
 
-    open fun addErrorListener(errorListener: ErrorListener) {
+    open fun visitMethodParameter(methodParameter: MethodParameter) {
+        visitNode(methodParameter.type)
+    }
+
+    open fun visitType(type: Type) {
+        type.of.forEach { visitNode(it) }
+    }
+
+    fun addErrorListener(errorListener: ErrorListener) {
         errorListeners.add(errorListener)
     }
 
-    open fun removeErrorListener(errorListener: ErrorListener) {
+    fun removeErrorListener(errorListener: ErrorListener) {
         errorListeners.remove(errorListener)
     }
 

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ParseContext.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ParseContext.kt
@@ -6,4 +6,8 @@
 
 package cloud.orbit.dsl.ast
 
-data class ParseContext(val filePath: String, val line: Int, val column: Int) : AstAnnotation
+data class ParseContext(val filePath: String, val line: Int, val column: Int) : AstAnnotation {
+    companion object {
+        val UNKNOWN = ParseContext("<unknown>", 0, 0)
+    }
+}

--- a/src/dsl/orbit-dsl-typecheck/build.gradle
+++ b/src/dsl/orbit-dsl-typecheck/build.gradle
@@ -1,0 +1,9 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+dependencies {
+    compile(project(":src:dsl:orbit-dsl-ast"))
+}

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/OrbitDslTypeChecker.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/OrbitDslTypeChecker.kt
@@ -1,0 +1,34 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import cloud.orbit.dsl.ast.CompilationUnit
+
+object OrbitDslTypeChecker {
+    private val checks = listOf(
+        TypeArityCheck(
+            mapOf(
+                "list" to TypeDescriptor("list", 1),
+                "map" to TypeDescriptor("map", 2)
+            )
+        )
+    )
+
+    fun checkTypes(compilationUnits: List<CompilationUnit>) {
+        val errorListener = TypeErrorListener()
+        val typeCheckingVisitor = TypeCheckingVisitor(checks)
+        typeCheckingVisitor.addErrorListener(errorListener)
+
+        compilationUnits.forEach {
+            typeCheckingVisitor.visitCompilationUnit(it)
+        }
+
+        if (errorListener.typeErrors.isNotEmpty()) {
+            throw OrbitDslTypeCheckingException(errorListener.typeErrors)
+        }
+    }
+}

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/OrbitDslTypeCheckingException.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/OrbitDslTypeCheckingException.kt
@@ -1,0 +1,11 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import java.lang.RuntimeException
+
+class OrbitDslTypeCheckingException(val typeErrors: Collection<OrbitDslTypeError>) : RuntimeException()

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/OrbitDslTypeError.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/OrbitDslTypeError.kt
@@ -1,0 +1,11 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+data class OrbitDslTypeError(val filePath: String, val line: Int, val column: Int, val message: String?) {
+    val errorMessage = "error: $filePath:$line:$column: ${message ?: "type error"}"
+}

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeArityCheck.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeArityCheck.kt
@@ -1,0 +1,24 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import cloud.orbit.dsl.ast.Type
+
+class TypeArityCheck(
+    private val knownTypes: Map<String, TypeDescriptor>
+) : TypeCheck() {
+    override fun check(type: Type) {
+        val descriptor = knownTypes[type.name] ?: return
+
+        if (type.of.size != descriptor.arity) {
+            reportError(
+                type,
+                "expected parameter count for type '${type.name}' is ${descriptor.arity}, found ${type.of.size}"
+            )
+        }
+    }
+}

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeCheck.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeCheck.kt
@@ -1,0 +1,29 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import cloud.orbit.dsl.ast.AstVisitor
+import cloud.orbit.dsl.ast.Type
+
+/**
+ * A type check for a single [Type] AST node.
+ *
+ * Derived classes should not visit type parameters. The invoking [TypeCheckingVisitor] is responsible for that.
+ *
+ */
+abstract class TypeCheck : AstVisitor() {
+    /**
+     * Runs a check against a type.
+     *
+     * @param type the type to check.
+     */
+    abstract fun check(type: Type)
+
+    override fun visitType(type: Type) {
+        check(type)
+    }
+}

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeCheckingVisitor.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeCheckingVisitor.kt
@@ -1,0 +1,36 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import cloud.orbit.dsl.ast.AstNode
+import cloud.orbit.dsl.ast.AstVisitor
+import cloud.orbit.dsl.ast.ErrorListener
+import cloud.orbit.dsl.ast.Type
+
+/**
+ * An AST visitor that runs a collection of type checks against each type visited.
+ *
+ * Errors reported by type checks are propagated to any [ErrorListener] instances registered against this visitor.
+ *
+ * @param typeChecks the checks to run against each type visited in the AST.
+ */
+class TypeCheckingVisitor(private val typeChecks: Collection<TypeCheck>) : AstVisitor(), ErrorListener {
+    init {
+        typeChecks.forEach {
+            it.addErrorListener(this)
+        }
+    }
+
+    override fun visitType(type: Type) {
+        typeChecks.forEach { it.visitNode(type) }
+        super.visitType(type)
+    }
+
+    override fun onError(astNode: AstNode, message: String) {
+        reportError(astNode, message)
+    }
+}

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeDescriptor.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeDescriptor.kt
@@ -1,0 +1,15 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+/**
+ * Contains information about a type.
+ *
+ * @param name the type name.
+ * @param arity the number of type parameters this type takes.
+ */
+data class TypeDescriptor (val name: String, val arity: Int)

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeErrorListener.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeErrorListener.kt
@@ -1,0 +1,27 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import cloud.orbit.dsl.ast.AstNode
+import cloud.orbit.dsl.ast.ErrorListener
+import cloud.orbit.dsl.ast.ParseContext
+
+class TypeErrorListener : ErrorListener {
+    val typeErrors = mutableListOf<OrbitDslTypeError>()
+
+    override fun onError(astNode: AstNode, message: String) {
+        val parseContext = astNode.getAnnotation() ?: ParseContext.UNKNOWN
+        typeErrors.add(
+            OrbitDslTypeError(
+                parseContext.filePath,
+                parseContext.line,
+                parseContext.column,
+                message
+            )
+        )
+    }
+}

--- a/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeArityCheckTest.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeArityCheckTest.kt
@@ -1,0 +1,54 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import cloud.orbit.dsl.ast.Type
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TypeArityCheckTest {
+    private val errorListener = TypeErrorListener()
+    private val typeArityCheck = TypeArityCheck(
+        mapOf(
+            "t0" to TypeDescriptor("t0", 0),
+            "t1" to TypeDescriptor("t1", 1),
+            "t2" to TypeDescriptor("t2", 2)
+        )
+    )
+
+    init {
+        typeArityCheck.addErrorListener(errorListener)
+    }
+
+    @Test
+    fun noOpWhenTypeIsUnknown() {
+        typeArityCheck.visitNode(Type("t"))
+
+        assertTrue(errorListener.typeErrors.isEmpty())
+    }
+
+    @Test
+    fun noErrorsWhenTypeArityIsCorrect() {
+        typeArityCheck.visitNode(Type("t0"))
+        typeArityCheck.visitNode(Type("t1", of = listOf(Type("t"))))
+        typeArityCheck.visitNode(Type("t2", of = listOf(Type("t"), Type("t"))))
+
+        assertTrue(errorListener.typeErrors.isEmpty())
+    }
+
+    @Test
+    fun reportsErrorWhenTypeArityIsIncorrect() {
+        typeArityCheck.visitNode(Type("t0", of = listOf(Type("t"))))
+        typeArityCheck.visitNode(Type("t1"))
+        typeArityCheck.visitNode(Type("t2", of = listOf(Type("t"))))
+
+        val errorMessages = errorListener.typeErrors.map { it.message }
+        assertTrue(errorMessages.contains("expected parameter count for type 't0' is 0, found 1"))
+        assertTrue(errorMessages.contains("expected parameter count for type 't1' is 1, found 0"))
+        assertTrue(errorMessages.contains("expected parameter count for type 't2' is 2, found 1"))
+    }
+}

--- a/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeCheckTest.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeCheckTest.kt
@@ -1,0 +1,28 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import cloud.orbit.dsl.ast.Type
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TypeCheckTest {
+    @Test
+    fun doesNotVisitTypeParameters() {
+        val typeCheck = object : TypeCheck() {
+            val visitedTypeNames = mutableListOf<String>()
+
+            override fun check(type: Type) {
+                visitedTypeNames.add(type.name)
+            }
+        }
+
+        typeCheck.visitNode(Type("t1", of = listOf(Type("t2"))))
+
+        assertEquals(listOf("t1"), typeCheck.visitedTypeNames)
+    }
+}

--- a/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeCheckingVisitorTest.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeCheckingVisitorTest.kt
@@ -1,0 +1,217 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import cloud.orbit.dsl.ast.ActorDeclaration
+import cloud.orbit.dsl.ast.ActorKeyType
+import cloud.orbit.dsl.ast.ActorMethod
+import cloud.orbit.dsl.ast.CompilationUnit
+import cloud.orbit.dsl.ast.DataDeclaration
+import cloud.orbit.dsl.ast.DataField
+import cloud.orbit.dsl.ast.MethodParameter
+import cloud.orbit.dsl.ast.Type
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TypeCheckingVisitorTest {
+    @Test
+    fun checksDataFieldTypes() {
+        val collectingTypeCheck = CollectingTypeCheck()
+        val visitor = TypeCheckingVisitor(listOf(collectingTypeCheck))
+        visitor.visitCompilationUnit(
+            CompilationUnit(
+                "cloud.orbit.test",
+                data = listOf(
+                    DataDeclaration(
+                        "data1",
+                        fields = listOf(
+                            DataField("field1", Type("ft1"), index = 1),
+                            DataField("field2", Type("ft2"), index = 2)
+                        )
+                    )
+                )
+            )
+        )
+
+        assertTrue(collectingTypeCheck.typesChecked.contains(Type("ft1")))
+        assertTrue(collectingTypeCheck.typesChecked.contains(Type("ft2")))
+    }
+
+    @Test
+    fun checksMethodReturnTypes() {
+        val collectingTypeCheck = CollectingTypeCheck()
+        val visitor = TypeCheckingVisitor(listOf(collectingTypeCheck))
+        visitor.visitCompilationUnit(
+            CompilationUnit(
+                "cloud.orbit.test",
+                actors = listOf(
+                    ActorDeclaration(
+                        "actor1",
+                        ActorKeyType.NO_KEY,
+                        methods = listOf(
+                            ActorMethod(
+                                "method1",
+                                returnType = Type("mrt1")
+                            ),
+                            ActorMethod(
+                                "method2",
+                                returnType = Type("mrt2")
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        assertTrue(collectingTypeCheck.typesChecked.contains(Type("mrt1")))
+        assertTrue(collectingTypeCheck.typesChecked.contains(Type("mrt2")))
+    }
+
+    @Test
+    fun checksMethodParameterTypes() {
+        val collectingTypeCheck = CollectingTypeCheck()
+        val visitor = TypeCheckingVisitor(listOf(collectingTypeCheck))
+        visitor.visitCompilationUnit(
+            CompilationUnit(
+                "cloud.orbit.test",
+                actors = listOf(
+                    ActorDeclaration(
+                        "actor1",
+                        ActorKeyType.NO_KEY,
+                        methods = listOf(
+                            ActorMethod(
+                                "method1",
+                                returnType = Type("mrt"),
+                                params = listOf(
+                                    MethodParameter(
+                                        "p1",
+                                        type = Type("mpt1")
+                                    ),
+                                    MethodParameter(
+                                        "p2",
+                                        type = Type("mpt2")
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        assertTrue(collectingTypeCheck.typesChecked.contains(Type("mpt1")))
+        assertTrue(collectingTypeCheck.typesChecked.contains(Type("mpt2")))
+    }
+
+    @Test
+    fun checksTypeParameters() {
+        val collectingTypeCheck = CollectingTypeCheck()
+        val visitor = TypeCheckingVisitor(listOf(collectingTypeCheck))
+        visitor.visitCompilationUnit(
+            CompilationUnit(
+                "cloud.orbit.test",
+                data = listOf(
+                    DataDeclaration(
+                        "data1",
+                        fields = listOf(
+                            DataField(
+                                "field1",
+                                type = Type(
+                                    "ft", of = listOf(
+                                        Type(
+                                            "tp1", of = listOf(
+                                                Type("tp11")
+                                            )
+                                        ),
+                                        Type("tp2")
+                                    )
+                                ),
+                                index = 1
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        assertTrue(
+            collectingTypeCheck.typesChecked.contains(
+                Type(
+                    "ft", of = listOf(
+                        Type(
+                            "tp1", of = listOf(
+                                Type("tp11")
+                            )
+                        ),
+                        Type("tp2")
+                    )
+                )
+            )
+        )
+        assertTrue(
+            collectingTypeCheck.typesChecked.contains(
+                Type(
+                    "tp1", of = listOf(
+                        Type("tp11")
+                    )
+                )
+            )
+        )
+        assertTrue(collectingTypeCheck.typesChecked.contains(Type("tp11")))
+        assertTrue(collectingTypeCheck.typesChecked.contains(Type("tp2")))
+    }
+
+    @Test
+    fun reportsTypeCheckErrors() {
+        val errorListener = TypeErrorListener()
+        val compilationUnit = CompilationUnit(
+            "cloud.orbit.test",
+            data = listOf(
+                DataDeclaration(
+                    "data1",
+                    fields = listOf(
+                        DataField(
+                            "field1",
+                            Type(
+                                "ft1",
+                                of = listOf(
+                                    Type("tp1")
+                                )
+                            ),
+                            index = 1
+                        )
+                    )
+                )
+            )
+        )
+
+        val visitor = TypeCheckingVisitor(listOf(ErrorReportingTypeCheck()))
+        visitor.addErrorListener(errorListener)
+        visitor.visitCompilationUnit(compilationUnit)
+        assertEquals(2, errorListener.typeErrors.size)
+
+        visitor.removeErrorListener(errorListener)
+        visitor.visitCompilationUnit(compilationUnit)
+        // No more errors reported
+        assertEquals(2, errorListener.typeErrors.size)
+    }
+
+    private class CollectingTypeCheck : TypeCheck() {
+        val typesChecked = mutableListOf<Type>()
+
+        override fun check(type: Type) {
+            typesChecked.add(type)
+        }
+    }
+
+    private class ErrorReportingTypeCheck : TypeCheck() {
+        override fun check(type: Type) {
+            reportError(type, "")
+        }
+    }
+}

--- a/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeErrorListenerTest.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeErrorListenerTest.kt
@@ -1,0 +1,50 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import cloud.orbit.dsl.ast.ParseContext
+import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.annotated
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class TypeErrorListenerTest {
+    @Test
+    fun reportsErrorWithParseContext() {
+        val typeErrorListener = TypeErrorListener()
+        typeErrorListener.onError(
+            Type("t")
+                .annotated(
+                    ParseContext(
+                        "path/to/file.orbit",
+                        line = 2,
+                        column = 17
+                    )
+                ),
+            "error here"
+        )
+
+        assertEquals(
+            OrbitDslTypeError("path/to/file.orbit", line = 2, column = 17, message = "error here"),
+            typeErrorListener.typeErrors.first()
+        )
+    }
+
+    @Test
+    fun reportsErrorWithUnknownParseContext() {
+        val typeErrorListener = TypeErrorListener()
+        typeErrorListener.onError(
+            Type("t"),
+            "error here"
+        )
+
+        assertEquals(
+            OrbitDslTypeError("<unknown>", line = 0, column = 0, message = "error here"),
+            typeErrorListener.typeErrors.first()
+        )
+    }
+}

--- a/src/plugins/orbit-gradle-plugin/build.gradle
+++ b/src/plugins/orbit-gradle-plugin/build.gradle
@@ -12,6 +12,7 @@ plugins {
 dependencies {
     compile(project(":src:dsl:orbit-dsl-java"))
     compile(project(":src:dsl:orbit-dsl-parsing"))
+    compile(project(":src:dsl:orbit-dsl-typecheck"))
 }
 
 gradlePlugin {


### PR DESCRIPTION
Basic infrastructure for us to start doing type checks. For now, we're only checking that `list` and `map` are being used with the right number of type parameters.

Main bits in this change:

* `OrbitDslTypeChecker` is the top-level object that is responsible for type checking a set of `CompilationUnit`s. Contains the list of default type checks.
* `TypeCheckingVisitor` is an `AstVisitor` that runs a list of type checks against each type visited in an AST
* `TypeCheck` is a an `AstVisitor` with an abstract method `check(Type)` where each check's logic should be written

For now, the Gradle plugin is responsible for coordinating file parson and type checking before code generation. A follow-up PR will introduce a new type responsible for doing that coordination, so we can move that logic away from the plugin.