### PR TITLE
DSL: rename Type to TypeReference

### DIFF
--- a/src/dsl/orbit-dsl-parsing/src/main/antlr/cloud/orbit/dsl/OrbitDsl.g4
+++ b/src/dsl/orbit-dsl-parsing/src/main/antlr/cloud/orbit/dsl/OrbitDsl.g4
@@ -19,14 +19,14 @@ declaration: enumDeclaration | actorDeclaration | dataDeclaration ;
 enumDeclaration: ENUM name=ID LC_BRACE members=enumMember* RC_BRACE ;
 enumMember: name=ID EQUAL index=INT SEMI_COLON ;
 
-actorDeclaration: ACTOR name=ID (L_ANGLE keyType=type R_ANGLE)? LC_BRACE methods=actorMethod* RC_BRACE ;
-actorMethod: returnType=type name=ID L_PAREN (args=methodParam (COMMA args=methodParam)*)? R_PAREN SEMI_COLON ;
-methodParam: type name=ID ;
+actorDeclaration: ACTOR name=ID (L_ANGLE keyType=typeReference R_ANGLE)? LC_BRACE methods=actorMethod* RC_BRACE ;
+actorMethod: returnType=typeReference name=ID L_PAREN (args=methodParam (COMMA args=methodParam)*)? R_PAREN SEMI_COLON ;
+methodParam: typeReference name=ID ;
 
 dataDeclaration: DATA name=ID LC_BRACE fields=dataField* RC_BRACE ;
-dataField: type name=ID EQUAL index=INT SEMI_COLON ;
+dataField: typeReference name=ID EQUAL index=INT SEMI_COLON ;
 
-type: name=ID (L_ANGLE of=type (COMMA of=type)* R_ANGLE)? ;
+typeReference: name=ID (L_ANGLE of=typeReference (COMMA of=typeReference)* R_ANGLE)? ;
 
 /* ====== LEXER ===== */
 

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/OrbitDslFileParser.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/OrbitDslFileParser.kt
@@ -17,7 +17,7 @@ import cloud.orbit.dsl.visitor.DataDeclarationVisitor
 import cloud.orbit.dsl.visitor.EnumDeclarationVisitor
 import cloud.orbit.dsl.visitor.AstNodeContextProvider
 import cloud.orbit.dsl.visitor.SyntaxVisitor
-import cloud.orbit.dsl.visitor.TypeVisitor
+import cloud.orbit.dsl.visitor.TypeReferenceVisitor
 import cloud.orbit.dsl.visitor.UnsupportedActorKeyTypeException
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
@@ -66,10 +66,10 @@ class OrbitDslFileParser {
                 AstNode.Context(ParseContext(input.filePath, token.line, token.charPositionInLine))
         }
 
-        val typeVisitor = TypeVisitor(contextProvider)
+        val typeReferenceVisitor = TypeReferenceVisitor(contextProvider)
         val enumDeclarationVisitor = EnumDeclarationVisitor(contextProvider)
-        val dataDeclarationVisitor = DataDeclarationVisitor(typeVisitor, contextProvider)
-        val actorDeclarationVisitor = ActorDeclarationVisitor(typeVisitor, contextProvider)
+        val dataDeclarationVisitor = DataDeclarationVisitor(typeReferenceVisitor, contextProvider)
+        val actorDeclarationVisitor = ActorDeclarationVisitor(typeReferenceVisitor, contextProvider)
 
         try {
             return CompilationUnitBuilderVisitor(

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/ActorDeclarationVisitor.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/ActorDeclarationVisitor.kt
@@ -8,14 +8,14 @@ package cloud.orbit.dsl.visitor
 
 import cloud.orbit.dsl.OrbitDslBaseVisitor
 import cloud.orbit.dsl.OrbitDslParser
-import cloud.orbit.dsl.OrbitDslParser.TypeContext
+import cloud.orbit.dsl.OrbitDslParser.TypeReferenceContext
 import cloud.orbit.dsl.ast.ActorDeclaration
 import cloud.orbit.dsl.ast.ActorKeyType
 import cloud.orbit.dsl.ast.ActorMethod
 import cloud.orbit.dsl.ast.MethodParameter
 
 class ActorDeclarationVisitor(
-    private val typeVisitor: TypeVisitor,
+    private val typeReferenceVisitor: TypeReferenceVisitor,
     private val contextProvider: AstNodeContextProvider
 ) : OrbitDslBaseVisitor<ActorDeclaration>() {
     override fun visitActorDeclaration(ctx: OrbitDslParser.ActorDeclarationContext) =
@@ -27,13 +27,13 @@ class ActorDeclarationVisitor(
                 .map { m ->
                     ActorMethod(
                         name = m.name.text,
-                        returnType = m.returnType.accept(typeVisitor),
+                        returnType = m.returnType.accept(typeReferenceVisitor),
                         params = m.children
                             .filterIsInstance(OrbitDslParser.MethodParamContext::class.java)
                             .map { p ->
                                 MethodParameter(
                                     name = p.name.text,
-                                    type = p.type().accept(typeVisitor),
+                                    type = p.typeReference().accept(typeReferenceVisitor),
                                     context = contextProvider.fromToken(p.name)
                                 )
                             }
@@ -43,7 +43,7 @@ class ActorDeclarationVisitor(
                 .toList(),
             context = contextProvider.fromToken(ctx.name))
 
-    private fun TypeContext.toActorKeyType() =
+    private fun TypeReferenceContext.toActorKeyType() =
         when (this.text) {
             "string" -> ActorKeyType.STRING
             "int32" -> ActorKeyType.INT32

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/DataDeclarationVisitor.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/DataDeclarationVisitor.kt
@@ -12,7 +12,7 @@ import cloud.orbit.dsl.ast.DataDeclaration
 import cloud.orbit.dsl.ast.DataField
 
 class DataDeclarationVisitor(
-    private val typeVisitor: TypeVisitor,
+    private val typeReferenceVisitor: TypeReferenceVisitor,
     private val contextProvider: AstNodeContextProvider
 ) : OrbitDslBaseVisitor<DataDeclaration>() {
     override fun visitDataDeclaration(ctx: OrbitDslParser.DataDeclarationContext) =
@@ -23,7 +23,7 @@ class DataDeclarationVisitor(
                 .map {
                     DataField(
                         name = it.name.text,
-                        type = it.type().accept(typeVisitor),
+                        type = it.typeReference().accept(typeReferenceVisitor),
                         index = it.index.text.toInt(),
                         context = contextProvider.fromToken(it.name)
                     )

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/TypeReferenceVisitor.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/TypeReferenceVisitor.kt
@@ -10,14 +10,14 @@ import cloud.orbit.dsl.OrbitDslBaseVisitor
 import cloud.orbit.dsl.OrbitDslParser
 import cloud.orbit.dsl.ast.Type
 
-class TypeVisitor(
+class TypeReferenceVisitor(
     private val contextProvider: AstNodeContextProvider
 ) : OrbitDslBaseVisitor<Type>() {
-    override fun visitType(ctx: OrbitDslParser.TypeContext) =
+    override fun visitTypeReference(ctx: OrbitDslParser.TypeReferenceContext) =
         Type(
             name = ctx.name.text,
             of = ctx.children
-                .filterIsInstance(OrbitDslParser.TypeContext::class.java)
+                .filterIsInstance(OrbitDslParser.TypeReferenceContext::class.java)
                 .map { it.accept(this) }
                 .toList(),
             context = contextProvider.fromToken(ctx.name)

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/ActorDeclarationVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/ActorDeclarationVisitorTest.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class ActorDeclarationVisitorTest {
-    private val visitor = ActorDeclarationVisitor(TypeVisitor(TestAstNodeContextProvider), TestAstNodeContextProvider)
+    private val visitor = ActorDeclarationVisitor(TypeReferenceVisitor(TestAstNodeContextProvider), TestAstNodeContextProvider)
 
     @Test
     fun buildsKeylessActorDeclaration() {

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/DataDeclarationVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/DataDeclarationVisitorTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class DataDeclarationVisitorTest {
-    private val visitor = DataDeclarationVisitor(TypeVisitor(TestAstNodeContextProvider), TestAstNodeContextProvider)
+    private val visitor = DataDeclarationVisitor(TypeReferenceVisitor(TestAstNodeContextProvider), TestAstNodeContextProvider)
 
     @Test
     fun buildsDataDeclaration() {

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/TypeReferenceVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/TypeReferenceVisitorTest.kt
@@ -11,8 +11,8 @@ import cloud.orbit.dsl.ast.Type
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
-class TypeVisitorTest {
-    private val visitor = TypeVisitor(TestAstNodeContextProvider)
+class TypeReferenceVisitorTest {
+    private val visitor = TypeReferenceVisitor(TestAstNodeContextProvider)
 
     @Test
     fun buildsSimpleType() {
@@ -24,7 +24,7 @@ class TypeVisitorTest {
                     Type("list", of = listOf(Type("int32")))
                 )
             ),
-            visitor.parse("map<string, list<int32>>", OrbitDslParser::type)
+            visitor.parse("map<string, list<int32>>", OrbitDslParser::typeReference)
         )
     }
 
@@ -38,7 +38,7 @@ class TypeVisitorTest {
                     Type("list", of = listOf(Type("int32")))
                 )
             ),
-            visitor.parse("map<string, list<int32>>", OrbitDslParser::type)
+            visitor.parse("map<string, list<int32>>", OrbitDslParser::typeReference)
         )
     }
 }


### PR DESCRIPTION
This is the first in a series of change that will introduce the difference between a "type reference" (an AST concept) and a "type" (a standalone concept).