### PR TITLE
DSL: rename Type to TypeReference (part 2)

### DIFF
--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ActorMethod.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ActorMethod.kt
@@ -8,7 +8,7 @@ package cloud.orbit.dsl.ast
 
 data class ActorMethod(
     val name: String,
-    val returnType: Type,
+    val returnType: TypeReference,
     val params: List<MethodParameter> = emptyList(),
     override val context: AstNode.Context = AstNode.Context.NONE
 ) : AstNode

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/AstVisitor.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/AstVisitor.kt
@@ -25,7 +25,7 @@ abstract class AstVisitor : ErrorReporter {
             is DataField -> visitDataField(node)
             is ActorMethod -> visitActorMethod(node)
             is MethodParameter -> visitMethodParameter(node)
-            is Type -> visitType(node)
+            is TypeReference -> visitTypeReference(node)
         }
     }
 
@@ -65,8 +65,8 @@ abstract class AstVisitor : ErrorReporter {
         visitNode(methodParameter.type)
     }
 
-    open fun visitType(type: Type) {
-        type.of.forEach { visitNode(it) }
+    open fun visitTypeReference(typeReference: TypeReference) {
+        typeReference.of.forEach { visitNode(it) }
     }
 
     fun addErrorListener(errorListener: ErrorListener) {

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/DataField.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/DataField.kt
@@ -8,7 +8,7 @@ package cloud.orbit.dsl.ast
 
 data class DataField(
     val name: String,
-    val type: Type,
+    val type: TypeReference,
     val index: Int,
     override val context: AstNode.Context = AstNode.Context.NONE
 ) : AstNode

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/MethodParameter.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/MethodParameter.kt
@@ -8,6 +8,6 @@ package cloud.orbit.dsl.ast
 
 data class MethodParameter(
     val name: String,
-    val type: Type,
+    val type: TypeReference,
     override val context: AstNode.Context = AstNode.Context.NONE
 ) : AstNode

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/TypeReference.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/TypeReference.kt
@@ -6,9 +6,9 @@
 
 package cloud.orbit.dsl.ast
 
-data class Type(
+data class TypeReference(
     val name: String,
-    val of: List<Type> = emptyList(),
+    val of: List<TypeReference> = emptyList(),
     override val context: AstNode.Context = AstNode.Context.NONE
 ) : AstNode {
     val isGeneric = of.isNotEmpty()

--- a/src/dsl/orbit-dsl-java/src/main/kotlin/cloud/orbit/dsl/java/JavaCodeGenerator.kt
+++ b/src/dsl/orbit-dsl-java/src/main/kotlin/cloud/orbit/dsl/java/JavaCodeGenerator.kt
@@ -12,7 +12,7 @@ import cloud.orbit.dsl.ast.AstVisitor
 import cloud.orbit.dsl.ast.CompilationUnit
 import cloud.orbit.dsl.ast.DataDeclaration
 import cloud.orbit.dsl.ast.EnumDeclaration
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.ParameterSpec
@@ -21,7 +21,7 @@ import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
-internal class JavaCodeGenerator(private val knownTypes: Map<Type, TypeName>) : AstVisitor() {
+internal class JavaCodeGenerator(private val knownTypes: Map<TypeReference, TypeName>) : AstVisitor() {
     private val completableFutureClass =
         ClassName.get("java.util.concurrent", "CompletableFuture")
 
@@ -104,12 +104,12 @@ internal class JavaCodeGenerator(private val knownTypes: Map<Type, TypeName>) : 
 
     private fun fieldToVariableName(fieldName: String) = fieldName.decapitalize()
 
-    private fun typeName(type: Type): TypeName =
+    private fun typeName(type: TypeReference): TypeName =
         if (!type.isGeneric) {
-            knownTypes.getValue(Type(type.name))
+            knownTypes.getValue(TypeReference(type.name))
         } else {
             ParameterizedTypeName.get(
-                knownTypes.getValue(Type(type.name)) as ClassName,
+                knownTypes.getValue(TypeReference(type.name)) as ClassName,
                 *type.of
                     .map(::typeName)
                     .map(TypeName::box)

--- a/src/dsl/orbit-dsl-java/src/main/kotlin/cloud/orbit/dsl/java/TypeIndexer.kt
+++ b/src/dsl/orbit-dsl-java/src/main/kotlin/cloud/orbit/dsl/java/TypeIndexer.kt
@@ -9,25 +9,25 @@ package cloud.orbit.dsl.java
 import cloud.orbit.dsl.ast.AstVisitor
 import cloud.orbit.dsl.ast.CompilationUnit
 import cloud.orbit.dsl.ast.Declaration
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.TypeName
 
 internal class TypeIndexer : AstVisitor() {
     private val types = mutableMapOf(
-        Type("boolean") to TypeName.BOOLEAN,
-        Type("double") to TypeName.DOUBLE,
-        Type("float") to TypeName.FLOAT,
-        Type("int32") to TypeName.INT,
-        Type("int64") to TypeName.LONG,
-        Type("string") to ClassName.get(String::class.java),
-        Type("list") to ClassName.get(java.util.List::class.java),
-        Type("map") to ClassName.get(java.util.Map::class.java)
+        TypeReference("boolean") to TypeName.BOOLEAN,
+        TypeReference("double") to TypeName.DOUBLE,
+        TypeReference("float") to TypeName.FLOAT,
+        TypeReference("int32") to TypeName.INT,
+        TypeReference("int64") to TypeName.LONG,
+        TypeReference("string") to ClassName.get(String::class.java),
+        TypeReference("list") to ClassName.get(java.util.List::class.java),
+        TypeReference("map") to ClassName.get(java.util.Map::class.java)
     )
 
     private var packageName: String = ""
 
-    fun visitCompilationUnits(compilationUnits: List<CompilationUnit>): Map<Type, TypeName> {
+    fun visitCompilationUnits(compilationUnits: List<CompilationUnit>): Map<TypeReference, TypeName> {
         compilationUnits.forEach { visitCompilationUnit(it) }
         return types
     }
@@ -38,6 +38,6 @@ internal class TypeIndexer : AstVisitor() {
     }
 
     override fun visitDeclaration(declaration: Declaration) {
-        types[Type(declaration.name)] = ClassName.get(packageName, declaration.name)
+        types[TypeReference(declaration.name)] = ClassName.get(packageName, declaration.name)
     }
 }

--- a/src/dsl/orbit-dsl-java/src/test/kotlin/cloud/orbit/dsl/java/JavaCodeGeneratorTest.kt
+++ b/src/dsl/orbit-dsl-java/src/test/kotlin/cloud/orbit/dsl/java/JavaCodeGeneratorTest.kt
@@ -15,7 +15,7 @@ import cloud.orbit.dsl.ast.DataField
 import cloud.orbit.dsl.ast.EnumDeclaration
 import cloud.orbit.dsl.ast.EnumMember
 import cloud.orbit.dsl.ast.MethodParameter
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -88,7 +88,7 @@ class JavaCodeGeneratorTest {
     fun generateData_SingleField() {
         val cu = CompilationUnit(
             packageName, data = listOf(
-                DataDeclaration("data1", listOf(DataField("Field1", Type("string"), 3)))
+                DataDeclaration("data1", listOf(DataField("Field1", TypeReference("string"), 3)))
             )
         )
 
@@ -116,8 +116,8 @@ class JavaCodeGeneratorTest {
             packageName, data = listOf(
                 DataDeclaration(
                     "data1", listOf(
-                        DataField("Field1", Type("string"), 3),
-                        DataField("Field2", Type("int32"), 5)
+                        DataField("Field1", TypeReference("string"), 3),
+                        DataField("Field2", TypeReference("int32"), 5)
                     )
                 )
             )
@@ -151,12 +151,12 @@ class JavaCodeGeneratorTest {
                 DataDeclaration(
                     "data1", listOf(
                         DataField(
-                            "field1", Type(
+                            "field1", TypeReference(
                                 "list", of = listOf(
-                                    Type(
+                                    TypeReference(
                                         "map", of = listOf(
-                                            Type("string"),
-                                            Type("int32")
+                                            TypeReference("string"),
+                                            TypeReference("int32")
                                         )
                                     )
                                 )
@@ -205,12 +205,12 @@ class JavaCodeGeneratorTest {
             ),
             data = listOf(
                 DataDeclaration(
-                    "data1", fields = listOf(DataField("field1", Type("string"), 1))
+                    "data1", fields = listOf(DataField("field1", TypeReference("string"), 1))
                 ),
                 DataDeclaration(
                     "data2", fields = listOf(
-                        DataField("field1", Type("list", of = listOf(Type("enum1"))), 1),
-                        DataField("field2", Type("list", of = listOf(Type("data1"))), 2)
+                        DataField("field1", TypeReference("list", of = listOf(TypeReference("enum1"))), 1),
+                        DataField("field2", TypeReference("list", of = listOf(TypeReference("data1"))), 2)
                     )
                 )
             )
@@ -339,7 +339,7 @@ class JavaCodeGeneratorTest {
     fun generateActor_SingleMethod() {
         val cu = CompilationUnit(
             packageName, actors = listOf(
-                ActorDeclaration("actor1", methods = listOf(ActorMethod("method1", Type("string"))))
+                ActorDeclaration("actor1", methods = listOf(ActorMethod("method1", TypeReference("string"))))
             )
         )
 
@@ -362,8 +362,8 @@ class JavaCodeGeneratorTest {
                 ActorDeclaration(
                     "actor1",
                     methods = listOf(
-                        ActorMethod("method1", Type("string")),
-                        ActorMethod("method2", Type("string"))
+                        ActorMethod("method1", TypeReference("string")),
+                        ActorMethod("method2", TypeReference("string"))
                     )
                 )
             )
@@ -391,8 +391,8 @@ class JavaCodeGeneratorTest {
                     methods = listOf(
                         ActorMethod(
                             "method1",
-                            Type("string"),
-                            params = listOf(MethodParameter("p1", Type("int32")))
+                            TypeReference("string"),
+                            params = listOf(MethodParameter("p1", TypeReference("int32")))
                         )
                     )
                 )
@@ -420,10 +420,10 @@ class JavaCodeGeneratorTest {
                     methods = listOf(
                         ActorMethod(
                             "method1",
-                            Type("string"),
+                            TypeReference("string"),
                             params = listOf(
-                                MethodParameter("p1", Type("int32")),
-                                MethodParameter("p2", Type("int32"))
+                                MethodParameter("p1", TypeReference("int32")),
+                                MethodParameter("p2", TypeReference("int32"))
                             )
                         )
                     )
@@ -452,8 +452,8 @@ class JavaCodeGeneratorTest {
                     methods = listOf(
                         ActorMethod(
                             "method1",
-                            Type("int32"),
-                            params = listOf(MethodParameter("p1", Type("int32")))
+                            TypeReference("int32"),
+                            params = listOf(MethodParameter("p1", TypeReference("int32")))
                         )
                     )
                 )
@@ -482,12 +482,12 @@ class JavaCodeGeneratorTest {
                     methods = listOf(
                         ActorMethod(
                             "method1",
-                            Type(
+                            TypeReference(
                                 "map", of = listOf(
-                                    Type("string"),
-                                    Type(
+                                    TypeReference("string"),
+                                    TypeReference(
                                         "list", of = listOf(
-                                            Type("list", of = listOf(Type("int64")))
+                                            TypeReference("list", of = listOf(TypeReference("int64")))
                                         )
                                     )
                                 )
@@ -530,7 +530,7 @@ class JavaCodeGeneratorTest {
                     "data1",
                     fields = listOf(
                         DataField(
-                            "field1", Type("string"), 1
+                            "field1", TypeReference("string"), 1
                         )
                     )
                 )
@@ -541,7 +541,7 @@ class JavaCodeGeneratorTest {
                     methods = listOf(
                         ActorMethod(
                             "method1",
-                            Type("map", of = listOf(Type("enum1"), Type("data1"))),
+                            TypeReference("map", of = listOf(TypeReference("enum1"), TypeReference("data1"))),
                             params = emptyList()
                         )
                     )
@@ -592,15 +592,15 @@ class JavaCodeGeneratorTest {
                     methods = listOf(
                         ActorMethod(
                             "method1",
-                            Type("int32"),
+                            TypeReference("int32"),
                             params = listOf(
                                 MethodParameter(
-                                    "arg1", type = Type(
+                                    "arg1", type = TypeReference(
                                         "map", of = listOf(
-                                            Type("string"),
-                                            Type(
+                                            TypeReference("string"),
+                                            TypeReference(
                                                 "list", of = listOf(
-                                                    Type("list", of = listOf(Type("int64")))
+                                                    TypeReference("list", of = listOf(TypeReference("int64")))
                                                 )
                                             )
                                         )
@@ -643,7 +643,7 @@ class JavaCodeGeneratorTest {
                     "data1",
                     fields = listOf(
                         DataField(
-                            "field1", Type("string"), 1
+                            "field1", TypeReference("string"), 1
                         )
                     )
                 )
@@ -654,12 +654,12 @@ class JavaCodeGeneratorTest {
                     methods = listOf(
                         ActorMethod(
                             "method1",
-                            Type("int32"),
+                            TypeReference("int32"),
                             params = listOf(
                                 MethodParameter(
-                                    "arg1", type = Type(
+                                    "arg1", type = TypeReference(
                                         "map", of =
-                                        listOf(Type("enum1"), Type("data1"))
+                                        listOf(TypeReference("enum1"), TypeReference("data1"))
                                     )
                                 )
                             )

--- a/src/dsl/orbit-dsl-java/src/test/kotlin/cloud/orbit/dsl/java/TypeIndexerTest.kt
+++ b/src/dsl/orbit-dsl-java/src/test/kotlin/cloud/orbit/dsl/java/TypeIndexerTest.kt
@@ -10,7 +10,7 @@ import cloud.orbit.dsl.ast.ActorDeclaration
 import cloud.orbit.dsl.ast.CompilationUnit
 import cloud.orbit.dsl.ast.DataDeclaration
 import cloud.orbit.dsl.ast.EnumDeclaration
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.TypeName
 import org.junit.jupiter.api.Assertions
@@ -18,14 +18,14 @@ import org.junit.jupiter.api.Test
 
 class TypeIndexerTest {
     private val expectedPredefinedTypes = mapOf(
-        Type("boolean") to TypeName.BOOLEAN,
-        Type("double") to TypeName.DOUBLE,
-        Type("float") to TypeName.FLOAT,
-        Type("int32") to TypeName.INT,
-        Type("int64") to TypeName.LONG,
-        Type("string") to ClassName.get(String::class.java),
-        Type("list") to ClassName.get(java.util.List::class.java),
-        Type("map") to ClassName.get(java.util.Map::class.java)
+        TypeReference("boolean") to TypeName.BOOLEAN,
+        TypeReference("double") to TypeName.DOUBLE,
+        TypeReference("float") to TypeName.FLOAT,
+        TypeReference("int32") to TypeName.INT,
+        TypeReference("int64") to TypeName.LONG,
+        TypeReference("string") to ClassName.get(String::class.java),
+        TypeReference("list") to ClassName.get(java.util.List::class.java),
+        TypeReference("map") to ClassName.get(java.util.Map::class.java)
     )
 
     @Test
@@ -42,7 +42,7 @@ class TypeIndexerTest {
             )
         )
 
-        val expectedTypes = mutableMapOf<Type, TypeName>(Type("bar") to ClassName.get("foo", "bar"))
+        val expectedTypes = mutableMapOf<TypeReference, TypeName>(TypeReference("bar") to ClassName.get("foo", "bar"))
         expectedTypes.putAll(expectedPredefinedTypes)
 
         Assertions.assertEquals(expectedTypes, actual)
@@ -56,7 +56,7 @@ class TypeIndexerTest {
             )
         )
 
-        val expectedTypes = mutableMapOf<Type, TypeName>(Type("bar") to ClassName.get("foo", "bar"))
+        val expectedTypes = mutableMapOf<TypeReference, TypeName>(TypeReference("bar") to ClassName.get("foo", "bar"))
         expectedTypes.putAll(expectedPredefinedTypes)
 
         Assertions.assertEquals(expectedTypes, actual)
@@ -70,7 +70,7 @@ class TypeIndexerTest {
             )
         )
 
-        val expectedTypes = mutableMapOf<Type, TypeName>(Type("bar") to ClassName.get("foo", "bar"))
+        val expectedTypes = mutableMapOf<TypeReference, TypeName>(TypeReference("bar") to ClassName.get("foo", "bar"))
         expectedTypes.putAll(expectedPredefinedTypes)
 
         Assertions.assertEquals(expectedTypes, actual)

--- a/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/TypeReferenceVisitor.kt
+++ b/src/dsl/orbit-dsl-parsing/src/main/kotlin/cloud/orbit/dsl/visitor/TypeReferenceVisitor.kt
@@ -8,13 +8,13 @@ package cloud.orbit.dsl.visitor
 
 import cloud.orbit.dsl.OrbitDslBaseVisitor
 import cloud.orbit.dsl.OrbitDslParser
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 
 class TypeReferenceVisitor(
     private val contextProvider: AstNodeContextProvider
-) : OrbitDslBaseVisitor<Type>() {
+) : OrbitDslBaseVisitor<TypeReference>() {
     override fun visitTypeReference(ctx: OrbitDslParser.TypeReferenceContext) =
-        Type(
+        TypeReference(
             name = ctx.name.text,
             of = ctx.children
                 .filterIsInstance(OrbitDslParser.TypeReferenceContext::class.java)

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/OrbitDslFileParserTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/OrbitDslFileParserTest.kt
@@ -17,7 +17,7 @@ import cloud.orbit.dsl.ast.EnumDeclaration
 import cloud.orbit.dsl.ast.EnumMember
 import cloud.orbit.dsl.ast.MethodParameter
 import cloud.orbit.dsl.ast.ParseContext
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import cloud.orbit.dsl.error.OrbitDslCompilationException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -234,7 +234,7 @@ class OrbitDslFileParserTest {
                                 )
                             ),
                             name = "field1",
-                            type = Type(
+                            type = TypeReference(
                                 context = AstNode.Context(
                                     ParseContext(
                                         filePath = testFilePath,
@@ -255,7 +255,7 @@ class OrbitDslFileParserTest {
                                 )
                             ),
                             name = "field2",
-                            type = Type(
+                            type = TypeReference(
                                 context = AstNode.Context(
                                     ParseContext(
                                         filePath = testFilePath,
@@ -291,7 +291,7 @@ class OrbitDslFileParserTest {
                                 )
                             ),
                             name = "no_args",
-                            returnType = Type(
+                            returnType = TypeReference(
                                 context = AstNode.Context(
                                     ParseContext(
                                         filePath = testFilePath,
@@ -311,7 +311,7 @@ class OrbitDslFileParserTest {
                                 )
                             ),
                             name = "one_arg",
-                            returnType = Type(
+                            returnType = TypeReference(
                                 context = AstNode.Context(
                                     ParseContext(
                                         filePath = testFilePath,
@@ -331,7 +331,7 @@ class OrbitDslFileParserTest {
                                         )
                                     ),
                                     name = "a",
-                                    type = Type(
+                                    type = TypeReference(
                                         context = AstNode.Context(
                                             ParseContext(
                                                 filePath = testFilePath,
@@ -353,7 +353,7 @@ class OrbitDslFileParserTest {
                                 )
                             ),
                             name = "multiple_args",
-                            returnType = Type(
+                            returnType = TypeReference(
                                 context = AstNode.Context(
                                     ParseContext(
                                         filePath = testFilePath,
@@ -373,7 +373,7 @@ class OrbitDslFileParserTest {
                                         )
                                     ),
                                     name = "arg1",
-                                    type = Type(
+                                    type = TypeReference(
                                         context = AstNode.Context(
                                             ParseContext(
                                                 filePath = testFilePath,
@@ -393,7 +393,7 @@ class OrbitDslFileParserTest {
                                         )
                                     ),
                                     name = "arg2",
-                                    type = Type(
+                                    type = TypeReference(
                                         context = AstNode.Context(
                                             ParseContext(
                                                 filePath = testFilePath,
@@ -415,7 +415,7 @@ class OrbitDslFileParserTest {
                                 )
                             ),
                             name = "generic_return",
-                            returnType = Type(
+                            returnType = TypeReference(
                                 context = AstNode.Context(
                                     ParseContext(
                                         filePath = testFilePath,
@@ -425,7 +425,7 @@ class OrbitDslFileParserTest {
                                 ),
                                 name = "list",
                                 of = listOf(
-                                    Type(
+                                    TypeReference(
                                         context = AstNode.Context(
                                             ParseContext(
                                                 filePath = testFilePath,
@@ -447,7 +447,7 @@ class OrbitDslFileParserTest {
                                 )
                             ),
                             name = "generic_arg",
-                            returnType = Type(
+                            returnType = TypeReference(
                                 context = AstNode.Context(
                                     ParseContext(
                                         filePath = testFilePath,
@@ -467,7 +467,7 @@ class OrbitDslFileParserTest {
                                         )
                                     ),
                                     name = "arg1",
-                                    type = Type(
+                                    type = TypeReference(
                                         context = AstNode.Context(
                                             ParseContext(
                                                 filePath = testFilePath,
@@ -476,7 +476,7 @@ class OrbitDslFileParserTest {
                                             )
                                         ),
                                         name = "list", of = listOf(
-                                            Type(
+                                            TypeReference(
                                                 context = AstNode.Context(
                                                     ParseContext(
                                                         filePath = testFilePath,
@@ -500,7 +500,7 @@ class OrbitDslFileParserTest {
                                 )
                             ),
                             name = "generic_multi",
-                            returnType = Type(
+                            returnType = TypeReference(
                                 context = AstNode.Context(
                                     ParseContext(
                                         filePath = testFilePath,
@@ -510,7 +510,7 @@ class OrbitDslFileParserTest {
                                 ),
                                 name = "map",
                                 of = listOf(
-                                    Type(
+                                    TypeReference(
                                         context = AstNode.Context(
                                             ParseContext(
                                                 filePath = testFilePath,
@@ -520,7 +520,7 @@ class OrbitDslFileParserTest {
                                         ),
                                         name = "RGB"
                                     ),
-                                    Type(
+                                    TypeReference(
                                         context = AstNode.Context(
                                             ParseContext(
                                                 filePath = testFilePath,
@@ -542,7 +542,7 @@ class OrbitDslFileParserTest {
                                         )
                                     ),
                                     name = "arg1",
-                                    type = Type(
+                                    type = TypeReference(
                                         context = AstNode.Context(
                                             ParseContext(
                                                 filePath = testFilePath,
@@ -552,7 +552,7 @@ class OrbitDslFileParserTest {
                                         ),
                                         name = "map",
                                         of = listOf(
-                                            Type(
+                                            TypeReference(
                                                 context = AstNode.Context(
                                                     ParseContext(
                                                         filePath = testFilePath,
@@ -562,7 +562,7 @@ class OrbitDslFileParserTest {
                                                 ),
                                                 name = "string"
                                             ),
-                                            Type(
+                                            TypeReference(
                                                 context = AstNode.Context(
                                                     ParseContext(
                                                         filePath = testFilePath,
@@ -586,7 +586,7 @@ class OrbitDslFileParserTest {
                                 )
                             ),
                             name = "generics_nested",
-                            returnType = Type(
+                            returnType = TypeReference(
                                 context = AstNode.Context(
                                     ParseContext(
                                         filePath = testFilePath,
@@ -596,7 +596,7 @@ class OrbitDslFileParserTest {
                                 ),
                                 name = "list",
                                 of = listOf(
-                                    Type(
+                                    TypeReference(
                                         context = AstNode.Context(
                                             ParseContext(
                                                 filePath = testFilePath,
@@ -606,7 +606,7 @@ class OrbitDslFileParserTest {
                                         ),
                                         name = "map",
                                         of = listOf(
-                                            Type(
+                                            TypeReference(
                                                 context = AstNode.Context(
                                                     ParseContext(
                                                         filePath = testFilePath,
@@ -616,7 +616,7 @@ class OrbitDslFileParserTest {
                                                 ),
                                                 name = "string"
                                             ),
-                                            Type(
+                                            TypeReference(
                                                 context = AstNode.Context(
                                                     ParseContext(
                                                         filePath = testFilePath,
@@ -640,7 +640,7 @@ class OrbitDslFileParserTest {
                                         )
                                     ),
                                     name = "arg1",
-                                    type = Type(
+                                    type = TypeReference(
                                         context = AstNode.Context(
                                             ParseContext(
                                                 filePath = testFilePath,
@@ -650,7 +650,7 @@ class OrbitDslFileParserTest {
                                         ),
                                         name = "map",
                                         of = listOf(
-                                            Type(
+                                            TypeReference(
                                                 context = AstNode.Context(
                                                     ParseContext(
                                                         filePath = testFilePath,
@@ -660,7 +660,7 @@ class OrbitDslFileParserTest {
                                                 ),
                                                 name = "string"
                                             ),
-                                            Type(
+                                            TypeReference(
                                                 context = AstNode.Context(
                                                     ParseContext(
                                                         filePath = testFilePath,
@@ -670,7 +670,7 @@ class OrbitDslFileParserTest {
                                                 ),
                                                 name = "list",
                                                 of = listOf(
-                                                    Type(
+                                                    TypeReference(
                                                         context = AstNode.Context(
                                                             ParseContext(
                                                                 filePath = testFilePath,
@@ -680,7 +680,7 @@ class OrbitDslFileParserTest {
                                                         ),
                                                         name = "list",
                                                         of = listOf(
-                                                            Type(
+                                                            TypeReference(
                                                                 context = AstNode.Context(
                                                                     ParseContext(
                                                                         filePath = testFilePath,

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/ActorDeclarationVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/ActorDeclarationVisitorTest.kt
@@ -11,7 +11,7 @@ import cloud.orbit.dsl.ast.ActorDeclaration
 import cloud.orbit.dsl.ast.ActorKeyType
 import cloud.orbit.dsl.ast.ActorMethod
 import cloud.orbit.dsl.ast.MethodParameter
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -76,21 +76,21 @@ class ActorDeclarationVisitorTest {
                 methods = listOf(
                     ActorMethod(
                         "method1",
-                        returnType = Type("void"),
+                        returnType = TypeReference("void"),
                         params = listOf(
                             MethodParameter(
                                 "n",
-                                type = Type("int32")
+                                type = TypeReference("int32")
                             )
                         )
                     ),
                     ActorMethod(
                         "method2",
-                        returnType = Type("int64"),
+                        returnType = TypeReference("int64"),
                         params = listOf(
                             MethodParameter(
                                 "s",
-                                type = Type("string")
+                                type = TypeReference("string")
                             )
                         )
                     )

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/DataDeclarationVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/DataDeclarationVisitorTest.kt
@@ -9,7 +9,7 @@ package cloud.orbit.dsl.visitor
 import cloud.orbit.dsl.OrbitDslParser
 import cloud.orbit.dsl.ast.DataDeclaration
 import cloud.orbit.dsl.ast.DataField
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -24,12 +24,12 @@ class DataDeclarationVisitorTest {
                 fields = listOf(
                     DataField(
                         "field1",
-                        type = Type("int32"),
+                        type = TypeReference("int32"),
                         index = 2
                     ),
                     DataField(
                         "field2",
-                        type = Type("string"),
+                        type = TypeReference("string"),
                         index = 5
                     )
                 )

--- a/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/TypeReferenceVisitorTest.kt
+++ b/src/dsl/orbit-dsl-parsing/src/test/kotlin/cloud/orbit/dsl/visitor/TypeReferenceVisitorTest.kt
@@ -7,7 +7,7 @@
 package cloud.orbit.dsl.visitor
 
 import cloud.orbit.dsl.OrbitDslParser
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -17,11 +17,11 @@ class TypeReferenceVisitorTest {
     @Test
     fun buildsSimpleType() {
         Assertions.assertEquals(
-            Type(
+            TypeReference(
                 "map",
                 of = listOf(
-                    Type("string"),
-                    Type("list", of = listOf(Type("int32")))
+                    TypeReference("string"),
+                    TypeReference("list", of = listOf(TypeReference("int32")))
                 )
             ),
             visitor.parse("map<string, list<int32>>", OrbitDslParser::typeReference)
@@ -31,11 +31,11 @@ class TypeReferenceVisitorTest {
     @Test
     fun buildsParameterizedType() {
         Assertions.assertEquals(
-            Type(
+            TypeReference(
                 "map",
                 of = listOf(
-                    Type("string"),
-                    Type("list", of = listOf(Type("int32")))
+                    TypeReference("string"),
+                    TypeReference("list", of = listOf(TypeReference("int32")))
                 )
             ),
             visitor.parse("map<string, list<int32>>", OrbitDslParser::typeReference)

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeArityCheck.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeArityCheck.kt
@@ -6,19 +6,19 @@
 
 package cloud.orbit.dsl
 
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import cloud.orbit.dsl.ast.error.ErrorReporter
 
 class TypeArityCheck(
     private val knownTypes: Map<String, TypeDescriptor>
 ) : TypeCheck {
-    override fun check(type: Type, context: TypeCheck.Context, errorReporter: ErrorReporter) {
-        val descriptor = knownTypes[type.name] ?: return
+    override fun check(typeReference: TypeReference, context: TypeCheck.Context, errorReporter: ErrorReporter) {
+        val descriptor = knownTypes[typeReference.name] ?: return
 
-        if (type.of.size != descriptor.arity) {
+        if (typeReference.of.size != descriptor.arity) {
             errorReporter.reportError(
-                type,
-                "expected parameter count for type '${type.name}' is ${descriptor.arity}, found ${type.of.size}"
+                typeReference,
+                "expected parameter count for type '${typeReference.name}' is ${descriptor.arity}, found ${typeReference.of.size}"
             )
         }
     }

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeCheck.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeCheck.kt
@@ -6,7 +6,7 @@
 
 package cloud.orbit.dsl
 
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import cloud.orbit.dsl.ast.error.ErrorReporter
 
 /**
@@ -18,10 +18,10 @@ interface TypeCheck {
     /**
      * Runs a check against a type.
      *
-     * @param type the type to check.
-     * @param context the context in which this type is being used (e.g. as a data field type).
+     * @param typeReference the reference to the type to check.
+     * @param context the context in which this type is being referenced (e.g. as a data field type).
      */
-    fun check(type: Type, context: Context, errorReporter: ErrorReporter)
+    fun check(typeReference: TypeReference, context: Context, errorReporter: ErrorReporter)
 
     enum class Context {
         DATA_FIELD,

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeCheckingVisitor.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeCheckingVisitor.kt
@@ -10,7 +10,7 @@ import cloud.orbit.dsl.ast.ActorMethod
 import cloud.orbit.dsl.ast.AstVisitor
 import cloud.orbit.dsl.ast.DataField
 import cloud.orbit.dsl.ast.MethodParameter
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 
 /**
  * An AST visitor that runs a collection of type checks against each type reference in the AST.
@@ -42,14 +42,14 @@ class TypeCheckingVisitor(private val typeChecks: Collection<TypeCheck>) : AstVi
         super.visitMethodParameter(methodParameter)
     }
 
-    override fun visitType(type: Type) {
-        // Don't check type itself since we know it's already been checked by a parent visit method
-        type.of.forEach { typeParameter ->
+    override fun visitTypeReference(typeReference: TypeReference) {
+        // Don't check typeReference itself since we know it's already been checked by a parent visit method
+        typeReference.of.forEach { typeParameter ->
             typeChecks.forEach {
                 it.check(typeParameter, TypeCheck.Context.TYPE_PARAMETER, errorReporter = this)
             }
         }
 
-        super.visitType(type)
+        super.visitTypeReference(typeReference)
     }
 }

--- a/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeArityCheckTest.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeArityCheckTest.kt
@@ -6,7 +6,7 @@
 
 package cloud.orbit.dsl
 
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -23,25 +23,25 @@ class TypeArityCheckTest {
 
     @Test
     fun noOpWhenTypeIsUnknown() {
-        typeArityCheck.check(Type("t"), context, errorReporter)
+        typeArityCheck.check(TypeReference("t"), context, errorReporter)
 
         assertTrue(errorReporter.errors.isEmpty())
     }
 
     @Test
     fun noErrorsWhenTypeArityIsCorrect() {
-        typeArityCheck.check(Type("t0"), context, errorReporter)
-        typeArityCheck.check(Type("t1", of = listOf(Type("t"))), context, errorReporter)
-        typeArityCheck.check(Type("t2", of = listOf(Type("t"), Type("t"))), context, errorReporter)
+        typeArityCheck.check(TypeReference("t0"), context, errorReporter)
+        typeArityCheck.check(TypeReference("t1", of = listOf(TypeReference("t"))), context, errorReporter)
+        typeArityCheck.check(TypeReference("t2", of = listOf(TypeReference("t"), TypeReference("t"))), context, errorReporter)
 
         assertTrue(errorReporter.errors.isEmpty())
     }
 
     @Test
     fun reportsErrorWhenTypeArityIsIncorrect() {
-        typeArityCheck.check(Type("t0", of = listOf(Type("t"))), context, errorReporter)
-        typeArityCheck.check(Type("t1"), context, errorReporter)
-        typeArityCheck.check(Type("t2", of = listOf(Type("t"))), context, errorReporter)
+        typeArityCheck.check(TypeReference("t0", of = listOf(TypeReference("t"))), context, errorReporter)
+        typeArityCheck.check(TypeReference("t1"), context, errorReporter)
+        typeArityCheck.check(TypeReference("t2", of = listOf(TypeReference("t"))), context, errorReporter)
 
         assertTrue(errorReporter.errors.contains("expected parameter count for type 't0' is 0, found 1"))
         assertTrue(errorReporter.errors.contains("expected parameter count for type 't1' is 1, found 0"))

--- a/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeCheckingVisitorTest.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeCheckingVisitorTest.kt
@@ -12,7 +12,7 @@ import cloud.orbit.dsl.ast.CompilationUnit
 import cloud.orbit.dsl.ast.DataDeclaration
 import cloud.orbit.dsl.ast.DataField
 import cloud.orbit.dsl.ast.MethodParameter
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import cloud.orbit.dsl.ast.error.ErrorReporter
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -30,7 +30,7 @@ class TypeCheckingVisitorTest {
                     DataDeclaration(
                         "d",
                         fields = listOf(
-                            DataField("f", Type("t"), index = 1)
+                            DataField("f", TypeReference("t"), index = 1)
                         )
                     )
                 )
@@ -39,7 +39,7 @@ class TypeCheckingVisitorTest {
 
         assertTrue(
             collectingTypeCheck.typesChecked.contains(
-                TypeCheckInvocation(Type("t"), TypeCheck.Context.DATA_FIELD)
+                TypeCheckInvocation(TypeReference("t"), TypeCheck.Context.DATA_FIELD)
             )
         )
     }
@@ -58,7 +58,7 @@ class TypeCheckingVisitorTest {
                         methods = listOf(
                             ActorMethod(
                                 "m",
-                                returnType = Type("t")
+                                returnType = TypeReference("t")
                             )
                         )
                     )
@@ -68,7 +68,7 @@ class TypeCheckingVisitorTest {
 
         assertTrue(
             collectingTypeCheck.typesChecked.contains(
-                TypeCheckInvocation(Type("t"), TypeCheck.Context.METHOD_RETURN)
+                TypeCheckInvocation(TypeReference("t"), TypeCheck.Context.METHOD_RETURN)
             )
         )
     }
@@ -87,11 +87,11 @@ class TypeCheckingVisitorTest {
                         methods = listOf(
                             ActorMethod(
                                 "m",
-                                returnType = Type("r"),
+                                returnType = TypeReference("r"),
                                 params = listOf(
                                     MethodParameter(
                                         "p",
-                                        type = Type("t")
+                                        type = TypeReference("t")
                                     )
                                 )
                             )
@@ -103,7 +103,7 @@ class TypeCheckingVisitorTest {
 
         assertTrue(
             collectingTypeCheck.typesChecked.contains(
-                TypeCheckInvocation(Type("t"), TypeCheck.Context.METHOD_PARAMETER)
+                TypeCheckInvocation(TypeReference("t"), TypeCheck.Context.METHOD_PARAMETER)
             )
         )
     }
@@ -122,14 +122,14 @@ class TypeCheckingVisitorTest {
                         fields = listOf(
                             DataField(
                                 "f",
-                                type = Type(
+                                type = TypeReference(
                                     "t1", of = listOf(
-                                        Type(
+                                        TypeReference(
                                             "t2", of = listOf(
-                                                Type("t3")
+                                                TypeReference("t3")
                                             )
                                         ),
-                                        Type("t4")
+                                        TypeReference("t4")
                                     )
                                 ),
                                 index = 1
@@ -143,14 +143,14 @@ class TypeCheckingVisitorTest {
         assertTrue(
             collectingTypeCheck.typesChecked.contains(
                 TypeCheckInvocation(
-                    Type(
+                    TypeReference(
                         "t1", of = listOf(
-                            Type(
+                            TypeReference(
                                 "t2", of = listOf(
-                                    Type("t3")
+                                    TypeReference("t3")
                                 )
                             ),
-                            Type("t4")
+                            TypeReference("t4")
                         )
                     ),
                     TypeCheck.Context.DATA_FIELD
@@ -160,9 +160,9 @@ class TypeCheckingVisitorTest {
         assertTrue(
             collectingTypeCheck.typesChecked.contains(
                 TypeCheckInvocation(
-                    Type(
+                    TypeReference(
                         "t2", of = listOf(
-                            Type("t3")
+                            TypeReference("t3")
                         )
                     ),
                     TypeCheck.Context.TYPE_PARAMETER
@@ -172,7 +172,7 @@ class TypeCheckingVisitorTest {
         assertTrue(
             collectingTypeCheck.typesChecked.contains(
                 TypeCheckInvocation(
-                    Type("t3"),
+                    TypeReference("t3"),
                     TypeCheck.Context.TYPE_PARAMETER
                 )
             )
@@ -180,20 +180,20 @@ class TypeCheckingVisitorTest {
         assertTrue(
             collectingTypeCheck.typesChecked.contains(
                 TypeCheckInvocation(
-                    Type("t4"),
+                    TypeReference("t4"),
                     TypeCheck.Context.TYPE_PARAMETER
                 )
             )
         )
     }
 
-    private data class TypeCheckInvocation(val type: Type, val context: TypeCheck.Context)
+    private data class TypeCheckInvocation(val type: TypeReference, val context: TypeCheck.Context)
 
     private class CollectingTypeCheck : TypeCheck {
         val typesChecked = mutableListOf<TypeCheckInvocation>()
 
-        override fun check(type: Type, context: TypeCheck.Context, errorReporter: ErrorReporter) {
-            typesChecked.add(TypeCheckInvocation(type, context))
+        override fun check(typeReference: TypeReference, context: TypeCheck.Context, errorReporter: ErrorReporter) {
+            typesChecked.add(TypeCheckInvocation(typeReference, context))
         }
     }
 }

--- a/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeErrorListenerTest.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeErrorListenerTest.kt
@@ -8,7 +8,7 @@ package cloud.orbit.dsl
 
 import cloud.orbit.dsl.ast.AstNode
 import cloud.orbit.dsl.ast.ParseContext
-import cloud.orbit.dsl.ast.Type
+import cloud.orbit.dsl.ast.TypeReference
 import cloud.orbit.dsl.error.OrbitDslError
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class TypeErrorListenerTest {
     fun reportsErrorWithParseContext() {
         val typeErrorListener = TypeErrorListener()
         typeErrorListener.onError(
-            Type(
+            TypeReference(
                 "t",
                 context = AstNode.Context(
                     ParseContext(
@@ -46,7 +46,7 @@ class TypeErrorListenerTest {
     fun reportsErrorWithUnknownParseContext() {
         val typeErrorListener = TypeErrorListener()
         typeErrorListener.onError(
-            Type("t"),
+            TypeReference("t"),
             "error here"
         )
 


### PR DESCRIPTION
First part (#384) only renamed grammar element and references. This one renamed the actual Kotlin type.