### PR TITLE
DSL: support void as a primitive type

### DIFF
--- a/src/dsl/orbit-dsl-common/src/main/kotlin/cloud/orbit/dsl/type/PrimitiveType.kt
+++ b/src/dsl/orbit-dsl-common/src/main/kotlin/cloud/orbit/dsl/type/PrimitiveType.kt
@@ -1,0 +1,19 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl.type
+
+object PrimitiveType {
+    const val BOOLEAN = "boolean"
+    const val DOUBLE = "double"
+    const val FLOAT = "float"
+    const val INT32 = "int32"
+    const val INT64 = "int64"
+    const val LIST = "list"
+    const val MAP = "map"
+    const val STRING = "string"
+    const val VOID = "void"
+}

--- a/src/dsl/orbit-dsl-java/build.gradle
+++ b/src/dsl/orbit-dsl-java/build.gradle
@@ -8,6 +8,7 @@ ext.javapoetVersion = "1.11.1"
 
 dependencies {
     compile(project(":src:dsl:orbit-dsl-ast"))
+    compile(project(":src:dsl:orbit-dsl-common"))
 
     compile("com.squareup:javapoet:$javapoetVersion")
 }

--- a/src/dsl/orbit-dsl-java/src/main/kotlin/cloud/orbit/dsl/java/TypeIndexer.kt
+++ b/src/dsl/orbit-dsl-java/src/main/kotlin/cloud/orbit/dsl/java/TypeIndexer.kt
@@ -10,19 +10,21 @@ import cloud.orbit.dsl.ast.AstVisitor
 import cloud.orbit.dsl.ast.CompilationUnit
 import cloud.orbit.dsl.ast.Declaration
 import cloud.orbit.dsl.ast.TypeReference
+import cloud.orbit.dsl.type.PrimitiveType
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.TypeName
 
 internal class TypeIndexer : AstVisitor() {
     private val types = mutableMapOf(
-        TypeReference("boolean") to TypeName.BOOLEAN,
-        TypeReference("double") to TypeName.DOUBLE,
-        TypeReference("float") to TypeName.FLOAT,
-        TypeReference("int32") to TypeName.INT,
-        TypeReference("int64") to TypeName.LONG,
-        TypeReference("string") to ClassName.get(String::class.java),
-        TypeReference("list") to ClassName.get(java.util.List::class.java),
-        TypeReference("map") to ClassName.get(java.util.Map::class.java)
+        TypeReference(PrimitiveType.BOOLEAN) to TypeName.BOOLEAN,
+        TypeReference(PrimitiveType.DOUBLE) to TypeName.DOUBLE,
+        TypeReference(PrimitiveType.FLOAT) to TypeName.FLOAT,
+        TypeReference(PrimitiveType.INT32) to TypeName.INT,
+        TypeReference(PrimitiveType.INT64) to TypeName.LONG,
+        TypeReference(PrimitiveType.LIST) to ClassName.get(java.util.List::class.java),
+        TypeReference(PrimitiveType.MAP) to ClassName.get(java.util.Map::class.java),
+        TypeReference(PrimitiveType.STRING) to ClassName.get(String::class.java),
+        TypeReference(PrimitiveType.VOID) to ClassName.get(Void::class.java)
     )
 
     private var packageName: String = ""

--- a/src/dsl/orbit-dsl-java/src/test/kotlin/cloud/orbit/dsl/java/TypeIndexerTest.kt
+++ b/src/dsl/orbit-dsl-java/src/test/kotlin/cloud/orbit/dsl/java/TypeIndexerTest.kt
@@ -17,62 +17,63 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class TypeIndexerTest {
-    private val expectedPredefinedTypes = mapOf(
-        TypeReference("boolean") to TypeName.BOOLEAN,
-        TypeReference("double") to TypeName.DOUBLE,
-        TypeReference("float") to TypeName.FLOAT,
-        TypeReference("int32") to TypeName.INT,
-        TypeReference("int64") to TypeName.LONG,
-        TypeReference("string") to ClassName.get(String::class.java),
-        TypeReference("list") to ClassName.get(java.util.List::class.java),
-        TypeReference("map") to ClassName.get(java.util.Map::class.java)
-    )
-
     @Test
     fun indexDefaultTypes() {
-        val actual = TypeIndexer().visitCompilationUnits(emptyList())
-        Assertions.assertEquals(expectedPredefinedTypes, actual)
+        val expectedPredefinedTypes = mapOf(
+            TypeReference("boolean") to TypeName.BOOLEAN,
+            TypeReference("double") to TypeName.DOUBLE,
+            TypeReference("float") to TypeName.FLOAT,
+            TypeReference("int32") to TypeName.INT,
+            TypeReference("int64") to TypeName.LONG,
+            TypeReference("string") to ClassName.get(String::class.java),
+            TypeReference("void") to ClassName.get(Void::class.java),
+            TypeReference("list") to ClassName.get(java.util.List::class.java),
+            TypeReference("map") to ClassName.get(java.util.Map::class.java)
+        )
+
+        val types = TypeIndexer().visitCompilationUnits(emptyList())
+        Assertions.assertEquals(expectedPredefinedTypes, types)
     }
 
     @Test
     fun indexEnum() {
-        val actual = TypeIndexer().visitCompilationUnits(
+        val types = TypeIndexer().visitCompilationUnits(
             listOf(
                 CompilationUnit("foo", enums = listOf(EnumDeclaration("bar")))
             )
         )
 
-        val expectedTypes = mutableMapOf<TypeReference, TypeName>(TypeReference("bar") to ClassName.get("foo", "bar"))
-        expectedTypes.putAll(expectedPredefinedTypes)
-
-        Assertions.assertEquals(expectedTypes, actual)
+        Assertions.assertEquals(
+            ClassName.get("foo", "bar"),
+            types[TypeReference("bar")]
+        )
     }
 
     @Test
     fun indexData() {
-        val actual = TypeIndexer().visitCompilationUnits(
+        val types = TypeIndexer().visitCompilationUnits(
             listOf(
                 CompilationUnit("foo", data = listOf(DataDeclaration("bar")))
             )
         )
 
-        val expectedTypes = mutableMapOf<TypeReference, TypeName>(TypeReference("bar") to ClassName.get("foo", "bar"))
-        expectedTypes.putAll(expectedPredefinedTypes)
-
-        Assertions.assertEquals(expectedTypes, actual)
+        Assertions.assertEquals(
+            ClassName.get("foo", "bar"),
+            types[TypeReference("bar")]
+        )
     }
 
     @Test
     fun indexActor() {
-        val actual = TypeIndexer().visitCompilationUnits(
+        val types = TypeIndexer().visitCompilationUnits(
             listOf(
                 CompilationUnit("foo", actors = listOf(ActorDeclaration("bar")))
             )
         )
 
-        val expectedTypes = mutableMapOf<TypeReference, TypeName>(TypeReference("bar") to ClassName.get("foo", "bar"))
-        expectedTypes.putAll(expectedPredefinedTypes)
-
-        Assertions.assertEquals(expectedTypes, actual)
+        Assertions.assertEquals(
+            ClassName.get("foo", "bar"),
+            types[TypeReference("bar")]
+        )
     }
 }

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/OrbitDslTypeChecker.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/OrbitDslTypeChecker.kt
@@ -11,6 +11,7 @@ import cloud.orbit.dsl.error.OrbitDslCompilationException
 
 object OrbitDslTypeChecker {
     private val checks = listOf(
+        VoidUsageCheck(),
         TypeArityCheck(
             mapOf(
                 "list" to TypeDescriptor("list", 1),

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/VoidUsageCheck.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/VoidUsageCheck.kt
@@ -1,0 +1,23 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import cloud.orbit.dsl.ast.TypeReference
+import cloud.orbit.dsl.ast.error.ErrorReporter
+import cloud.orbit.dsl.type.PrimitiveType
+
+class VoidUsageCheck : TypeCheck {
+    override fun check(typeReference: TypeReference, context: TypeCheck.Context, errorReporter: ErrorReporter) {
+        if (typeReference.name != PrimitiveType.VOID) {
+            return
+        }
+
+        if (context != TypeCheck.Context.METHOD_RETURN) {
+            errorReporter.reportError(typeReference, "'void' can only be used as method return type")
+        }
+    }
+}

--- a/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/OrbitDslTypeCheckerTest.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/OrbitDslTypeCheckerTest.kt
@@ -1,0 +1,66 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import cloud.orbit.dsl.ast.CompilationUnit
+import cloud.orbit.dsl.ast.DataDeclaration
+import cloud.orbit.dsl.ast.DataField
+import cloud.orbit.dsl.ast.TypeReference
+import cloud.orbit.dsl.error.OrbitDslCompilationException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class OrbitDslTypeCheckerTest {
+    @Test
+    fun checksTypeArity() {
+        val compilationUnit = CompilationUnit(
+            "cloud.orbit.test",
+            data = listOf(
+                DataDeclaration(
+                    name = "d1",
+                    fields = listOf(
+                        DataField(
+                            name = "f1",
+                            type = TypeReference(
+                                name = "map",
+                                of = listOf(TypeReference("string")) // wrong arity
+                            ),
+                            index = 1
+                        )
+                    )
+                )
+            )
+        )
+
+        assertThrows<OrbitDslCompilationException> {
+            OrbitDslTypeChecker.checkTypes(listOf(compilationUnit))
+        }
+    }
+
+    @Test
+    fun checksVoidUsage() {
+        val compilationUnit = CompilationUnit(
+            "cloud.orbit.test",
+            data = listOf(
+                DataDeclaration(
+                    name = "d1",
+                    fields = listOf(
+                        DataField(
+                            name = "f1",
+                            type = TypeReference("void"),
+                            index = 1
+                        )
+                    )
+                )
+            )
+        )
+
+        assertThrows<OrbitDslCompilationException> {
+            OrbitDslTypeChecker.checkTypes(listOf(compilationUnit))
+        }
+    }
+}

--- a/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TestErrorReporter.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TestErrorReporter.kt
@@ -15,5 +15,4 @@ class TestErrorReporter : ErrorReporter {
     override fun reportError(astNode: AstNode, message: String) {
         errors.add(message)
     }
-
 }

--- a/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/VoidUsageCheckTest.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/VoidUsageCheckTest.kt
@@ -1,0 +1,52 @@
+/*
+ Copyright (C) 2015 - 2019 Electronic Arts Inc.  All rights reserved.
+ This file is part of the Orbit Project <https://www.orbit.cloud>.
+ See license in LICENSE.
+ */
+
+package cloud.orbit.dsl
+
+import cloud.orbit.dsl.ast.TypeReference
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class VoidUsageCheckTest {
+    private lateinit var check: VoidUsageCheck
+    private lateinit var errorReporter: TestErrorReporter
+
+    @BeforeEach
+    fun beforeEach() {
+        check = VoidUsageCheck()
+        errorReporter = TestErrorReporter()
+    }
+
+    @Test
+    fun doesNotReportErrorOnNonVoidTypeReference() {
+        check.check(TypeReference("any"), TypeCheck.Context.DATA_FIELD, errorReporter)
+
+        assertTrue(errorReporter.errors.isEmpty())
+    }
+
+    @Test
+    fun doesNotReportErrorOnMethodReturn() {
+        check.check(TypeReference("void"), TypeCheck.Context.METHOD_RETURN, errorReporter)
+
+        assertTrue(errorReporter.errors.isEmpty())
+    }
+
+    @Test
+    fun reportsErrorOnNonMethodReturn() {
+        val typeCheckContexts = TypeCheck.Context.values().filter {
+            it != TypeCheck.Context.METHOD_RETURN
+        }
+
+        typeCheckContexts.forEach {
+            check.check(TypeReference("void"), it, errorReporter)
+        }
+
+        assertEquals(typeCheckContexts.size, errorReporter.errors.size)
+        assertTrue(errorReporter.errors.all { it == "'void' can only be used as method return type" })
+    }
+}


### PR DESCRIPTION
Add `void` as a primitive type, along with a type check that verifies it is only used as a method return type.