### PR TITLE
DSL: simplify error listening and reporting

### DIFF
--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/AstVisitor.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/AstVisitor.kt
@@ -6,12 +6,9 @@
 
 package cloud.orbit.dsl.ast
 
-import cloud.orbit.dsl.ast.error.ErrorListener
-import cloud.orbit.dsl.ast.error.ErrorReporter
-
-abstract class AstVisitor : ErrorReporter {
-    private val errorListeners = mutableSetOf<ErrorListener>()
-
+abstract class AstVisitor(
+    private val errorListener: ErrorListener = ErrorListener.DEFAULT
+) : ErrorReporter {
     open fun visitCompilationUnit(cu: CompilationUnit) {
         cu.enums.forEach { visitNode(it) }
         cu.data.forEach { visitNode(it) }
@@ -70,17 +67,7 @@ abstract class AstVisitor : ErrorReporter {
         typeReference.of.forEach { visitNode(it) }
     }
 
-    fun addErrorListener(errorListener: ErrorListener) {
-        errorListeners.add(errorListener)
-    }
-
-    fun removeErrorListener(errorListener: ErrorListener) {
-        errorListeners.remove(errorListener)
-    }
-
     override fun reportError(astNode: AstNode, message: String) {
-        errorListeners.forEach {
-            it.onError(astNode, message)
-        }
+        errorListener.onError(astNode, message)
     }
 }

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ErrorListener.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ErrorListener.kt
@@ -4,10 +4,14 @@
  See license in LICENSE.
  */
 
-package cloud.orbit.dsl.ast.error
-
-import cloud.orbit.dsl.ast.AstNode
+package cloud.orbit.dsl.ast
 
 interface ErrorListener {
     fun onError(astNode: AstNode, message: String)
+
+    companion object {
+        val DEFAULT = object : ErrorListener {
+            override fun onError(astNode: AstNode, message: String) {}
+        }
+    }
 }

--- a/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ErrorReporter.kt
+++ b/src/dsl/orbit-dsl-ast/src/main/kotlin/cloud/orbit/dsl/ast/ErrorReporter.kt
@@ -4,9 +4,7 @@
  See license in LICENSE.
  */
 
-package cloud.orbit.dsl.ast.error
-
-import cloud.orbit.dsl.ast.AstNode
+package cloud.orbit.dsl.ast
 
 interface ErrorReporter {
     fun reportError(astNode: AstNode, message: String)

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/ActorKeyTypeCheck.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/ActorKeyTypeCheck.kt
@@ -7,7 +7,7 @@
 package cloud.orbit.dsl
 
 import cloud.orbit.dsl.ast.TypeReference
-import cloud.orbit.dsl.ast.error.ErrorReporter
+import cloud.orbit.dsl.ast.ErrorReporter
 import cloud.orbit.dsl.type.PrimitiveType
 
 class ActorKeyTypeCheck : TypeCheck {

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/OrbitDslTypeChecker.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/OrbitDslTypeChecker.kt
@@ -23,8 +23,7 @@ object OrbitDslTypeChecker {
 
     fun checkTypes(compilationUnits: List<CompilationUnit>) {
         val errorListener = TypeErrorListener()
-        val typeCheckingVisitor = TypeCheckingVisitor(checks)
-        typeCheckingVisitor.addErrorListener(errorListener)
+        val typeCheckingVisitor = TypeCheckingVisitor(checks, errorListener)
 
         compilationUnits.forEach {
             typeCheckingVisitor.visitCompilationUnit(it)

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeArityCheck.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeArityCheck.kt
@@ -7,7 +7,7 @@
 package cloud.orbit.dsl
 
 import cloud.orbit.dsl.ast.TypeReference
-import cloud.orbit.dsl.ast.error.ErrorReporter
+import cloud.orbit.dsl.ast.ErrorReporter
 
 class TypeArityCheck(
     private val knownTypes: Map<String, TypeDescriptor>

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeCheck.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeCheck.kt
@@ -7,7 +7,7 @@
 package cloud.orbit.dsl
 
 import cloud.orbit.dsl.ast.TypeReference
-import cloud.orbit.dsl.ast.error.ErrorReporter
+import cloud.orbit.dsl.ast.ErrorReporter
 
 /**
  * A type check.

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeCheckingVisitor.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeCheckingVisitor.kt
@@ -10,6 +10,7 @@ import cloud.orbit.dsl.ast.ActorDeclaration
 import cloud.orbit.dsl.ast.ActorMethod
 import cloud.orbit.dsl.ast.AstVisitor
 import cloud.orbit.dsl.ast.DataField
+import cloud.orbit.dsl.ast.ErrorListener
 import cloud.orbit.dsl.ast.MethodParameter
 import cloud.orbit.dsl.ast.TypeReference
 
@@ -18,7 +19,10 @@ import cloud.orbit.dsl.ast.TypeReference
  *
  * @param typeChecks the type checks to run.
  */
-class TypeCheckingVisitor(private val typeChecks: Collection<TypeCheck>) : AstVisitor() {
+class TypeCheckingVisitor(
+    private val typeChecks: Collection<TypeCheck>,
+    private val errorListener: ErrorListener = ErrorListener.DEFAULT
+) : AstVisitor(errorListener) {
     override fun visitDataField(field: DataField) {
         typeChecks.forEach {
             it.check(field.type, TypeCheck.Context.DATA_FIELD, errorReporter = this)

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeErrorListener.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/TypeErrorListener.kt
@@ -7,7 +7,7 @@
 package cloud.orbit.dsl
 
 import cloud.orbit.dsl.ast.AstNode
-import cloud.orbit.dsl.ast.error.ErrorListener
+import cloud.orbit.dsl.ast.ErrorListener
 import cloud.orbit.dsl.error.OrbitDslError
 
 class TypeErrorListener : ErrorListener {

--- a/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/VoidUsageCheck.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/main/kotlin/cloud/orbit/dsl/VoidUsageCheck.kt
@@ -7,7 +7,7 @@
 package cloud.orbit.dsl
 
 import cloud.orbit.dsl.ast.TypeReference
-import cloud.orbit.dsl.ast.error.ErrorReporter
+import cloud.orbit.dsl.ast.ErrorReporter
 import cloud.orbit.dsl.type.PrimitiveType
 
 class VoidUsageCheck : TypeCheck {

--- a/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TestErrorReporter.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TestErrorReporter.kt
@@ -7,7 +7,7 @@
 package cloud.orbit.dsl
 
 import cloud.orbit.dsl.ast.AstNode
-import cloud.orbit.dsl.ast.error.ErrorReporter
+import cloud.orbit.dsl.ast.ErrorReporter
 
 class TestErrorReporter : ErrorReporter {
     val errors = mutableListOf<String>()

--- a/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeCheckingVisitorTest.kt
+++ b/src/dsl/orbit-dsl-typecheck/src/test/kotlin/cloud/orbit/dsl/TypeCheckingVisitorTest.kt
@@ -13,7 +13,7 @@ import cloud.orbit.dsl.ast.DataDeclaration
 import cloud.orbit.dsl.ast.DataField
 import cloud.orbit.dsl.ast.MethodParameter
 import cloud.orbit.dsl.ast.TypeReference
-import cloud.orbit.dsl.ast.error.ErrorReporter
+import cloud.orbit.dsl.ast.ErrorReporter
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
* Collection of `ErrorListener`s in `AstVisitor` is unnecessary complexity - we can add a composite listener if we ever need to
* Default to no-op listener
* Move `ErrorListener` and `ErrorReporter` from `cloud.orbit.dsl.ast.error` to ` cloud.orbit.dsl.ast`