### PR TITLE
Disable class info for resource only scan.

### DIFF
--- a/actors/core/src/main/java/cloud/orbit/actors/runtime/DefaultClassDictionary.java
+++ b/actors/core/src/main/java/cloud/orbit/actors/runtime/DefaultClassDictionary.java
@@ -97,7 +97,7 @@ public class DefaultClassDictionary
             }
 
             long start = System.currentTimeMillis();
-            try (ScanResult scanResult = new ClassGraph().enableClassInfo().scan())
+            try (ScanResult scanResult = new ClassGraph().scan())
             {
                 scanResult.getResourcesWithExtension(EXTENSION)
                         .filter(r -> r.getPath().startsWith(META_INF_SERVICES_ORBIT_CLASSES))


### PR DESCRIPTION
Our new auto-balancing actor system caused Orbit to invoke cloud.orbit.actors.runtime.DefaultClassDictionary#ensureLoaded which causes services configured with a small heap to OOM.