### PR TITLE
Fix KryoSerializer concurrency bug (introduced in 5735ac14)

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/KryoSerializer.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/KryoSerializer.java
@@ -71,6 +71,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Kryo based message serializer and object cloning implementation.
@@ -92,16 +93,27 @@ public class KryoSerializer implements ExecutionObjectCloner, MessageSerializer
 
     public KryoSerializer(Consumer<Kryo> kryoConsumer)
     {
-        this(kryoConsumer, new DefaultClassResolver());
+        this(kryoConsumer, DefaultClassResolver::new);
     }
 
+    /**
+     * @deprecated Do not use this constructor, since it will share a single ClassResolver between Kryo instances in the
+     * Kryo pool which can cause concurrency issues.
+     */
+    @Deprecated
     public KryoSerializer(Consumer<Kryo> kryoConsumer, ClassResolver classResolver)
+    {
+        this(kryoConsumer, () -> classResolver);
+    }
+
+    public KryoSerializer(Consumer<Kryo> kryoConsumer, Supplier<ClassResolver> classResolverSupplier)
     {
         KryoFactory factory = new KryoFactory()
         {
             @Override
             public Kryo create()
             {
+                ClassResolver classResolver = classResolverSupplier.get();
                 Kryo kryo = new Kryo(new ClassResolver()
                 {
                     Kryo kryo;

--- a/actors/runtime/src/test/java/cloud/orbit/actors/runtime/KryoSerializerConcurrencyTest.java
+++ b/actors/runtime/src/test/java/cloud/orbit/actors/runtime/KryoSerializerConcurrencyTest.java
@@ -1,0 +1,73 @@
+/*
+ Copyright (C) 2019 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cloud.orbit.actors.runtime;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class KryoSerializerConcurrencyTest
+{
+    @Test
+    public void testConcurrentDeserializations() throws Exception
+    {
+        KryoSerializer kryoSerializer = new KryoSerializer();
+        BasicRuntime basicRuntime = Mockito.mock(BasicRuntime.class);
+        ExecutorService executorService = Executors.newFixedThreadPool(16);
+        byte[] bytes = kryoSerializer.serializeMessage(basicRuntime, new Message().withPayload(new MyDTO()));
+        Throwable[] t = new Throwable[]{null};
+        CountDownLatch latch = new CountDownLatch(160);
+        for (int i = 0; i < 160; i++)
+        {
+            executorService.execute(() -> {
+                try
+                {
+                    kryoSerializer.deserializeMessage(basicRuntime, bytes);
+                }
+                catch (Exception e)
+                {
+                    t[0] = e;
+                    e.printStackTrace();
+                }
+                latch.countDown();
+            });
+        }
+        latch.await();
+        Assert.assertNull(t[0]);
+    }
+
+    public class MyDTO
+    {
+        int a;
+    }
+}


### PR DESCRIPTION
The KryoSerializer was prone to serialization errors caused by concurrent serialization.

The KryoSerializer maintains a pool of Kryo objects which are not thread safe. In commit 5735ac14, the ClassResolver was changed from being one-per-Kryo object to a single ClassResolver which is shared by all Kryo objects. This is the bug.

This fix adds a new constructor which takes a `Supplier<ClassResolver>`, and a different ClassResolver is retrieved for each Kryo in the pool.