### PR TITLE
Use correct thread for selectNode.

### DIFF
--- a/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
+++ b/actors/runtime/src/main/java/cloud/orbit/actors/runtime/Hosting.java
@@ -392,7 +392,8 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
         final DistributedMap<RemoteKey, NodeAddress> distributedDirectory = getDistributedDirectory();
 
         // Get the existing activation from the distributed cache (if any)
-        NodeAddress nodeAddress = await(distributedDirectory.get(remoteKey));
+        NodeAddress nodeAddress = await(distributedDirectory.get(remoteKey)
+                .whenCompleteAsync((r, e) -> {}, stage.getExecutionPool()));
         if (nodeAddress != null)
         {
             // Target node still valid?
@@ -408,7 +409,8 @@ public class Hosting implements NodeCapabilities, Startable, PipelineExtension
             else
             {
                 // Target node is now dead, remove this activation from distributed cache
-                await(distributedDirectory.remove(remoteKey, nodeAddress));
+                await(distributedDirectory.remove(remoteKey, nodeAddress)
+                        .whenCompleteAsync((r, e) -> { }, stage.getExecutionPool()));
             }
         }
         nodeAddress = null;


### PR DESCRIPTION
In some cases the distributedDirectory implementation may return on its own callback thread and may be blocked in selectNode waiting for a node to join the cluster hosting a particular actor.

"jgroups-13,x-service-1@11978" prio=5 tid=0xa2 nid=NA waiting
java.lang.Thread.State: WAITING
at java.lang.Object.wait(Object.java:-1)
at cloud.orbit.actors.runtime.Hosting.waitForServers(Hosting.java:612)
at cloud.orbit.actors.runtime.Hosting.selectNode(Hosting.java:519)
at cloud.orbit.actors.runtime.Hosting.async$locateAndActivateActor(Hosting.java:434)
at cloud.orbit.actors.runtime.Hosting$$Lambda$630.450562970.apply(Unknown Source:-1)
at java.util.concurrent.CompletableFuture.uniCompose(CompletableFuture.java:952)
at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:926)
at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474)
at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:1962)
at cloud.orbit.concurrent.Task.internalComplete(Task.java:138)
at cloud.orbit.concurrent.Task.lambda$from$1(Task.java:187)
at cloud.orbit.concurrent.Task$$Lambda$121.2022378646.apply(Unknown Source:-1)