### PR TITLE
Better instrumenting

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,22 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/src/orbit-server/src/main/kotlin/orbit/server/mesh/NodeDirectory.kt
+++ b/src/orbit-server/src/main/kotlin/orbit/server/mesh/NodeDirectory.kt
@@ -6,11 +6,12 @@
 
 package orbit.server.mesh
 
+import orbit.server.service.HealthCheck
 import orbit.shared.mesh.NodeId
 import orbit.shared.mesh.NodeInfo
 import orbit.util.concurrent.AsyncMap
 
-interface NodeDirectory : AsyncMap<NodeId, NodeInfo> {
+interface NodeDirectory : AsyncMap<NodeId, NodeInfo>, HealthCheck {
     suspend fun entries(): Iterable<Pair<NodeId, NodeInfo>>
     suspend fun tick() {}
 }

--- a/src/orbit-server/src/main/kotlin/orbit/server/mesh/local/LocalNodeDirectory.kt
+++ b/src/orbit-server/src/main/kotlin/orbit/server/mesh/local/LocalNodeDirectory.kt
@@ -33,6 +33,10 @@ class LocalNodeDirectory(private val clock: Clock) :
         }
     }
 
+    override suspend fun isHealthy(): Boolean {
+        return true
+    }
+
     override suspend fun tick() {
         // Cull expired
         globalMap.values.filter { clock.inPast(it.lease.expiresAt) }.also { toDelete ->

--- a/src/orbit-server/src/main/kotlin/orbit/server/net/RemoteMeshNodeManager.kt
+++ b/src/orbit-server/src/main/kotlin/orbit/server/net/RemoteMeshNodeManager.kt
@@ -48,6 +48,7 @@ class RemoteMeshNodeManager(
         meshNodes.forEach { node ->
             logger.info("Connecting to peer ${node.id.key} @${node.url}...")
             this.connections[node.id] = RemoteMeshNodeConnection(localNode, node)
+            logger.debug { "${localNode.info.id} -> ${connections.map { c -> c.key }}"}
         }
 
         connections.values.forEach { node ->
@@ -55,6 +56,7 @@ class RemoteMeshNodeManager(
                 logger.info("Removing peer ${node.id.key}...")
                 connections[node.id]!!.disconnect()
                 connections.remove(node.id)
+                logger.debug { "${localNode.info.id} -> ${connections.map { c -> c.key }}"}
             }
         }
 

--- a/src/orbit-server/src/main/kotlin/orbit/server/service/HealthCheckList.kt
+++ b/src/orbit-server/src/main/kotlin/orbit/server/service/HealthCheckList.kt
@@ -9,16 +9,19 @@ package orbit.server.service
 import orbit.server.OrbitServer
 import orbit.server.mesh.AddressableDirectory
 import orbit.server.mesh.LocalNodeInfo
+import orbit.server.mesh.NodeDirectory
 
 class HealthCheckList(
     private val server: OrbitServer,
     private val localNodeInfo: LocalNodeInfo,
-    private val addressableDirectory: AddressableDirectory
+    private val addressableDirectory: AddressableDirectory,
+    private val nodeDirectory: NodeDirectory
 ) {
     val checks = listOf(
         this.server,
         this.localNodeInfo,
-        this.addressableDirectory
+        this.addressableDirectory,
+        this.nodeDirectory
     )
 
     fun getChecks(): Iterable<HealthCheck> {


### PR DESCRIPTION
Remove log spam from node directory refreshes by using etcd leases instead of a refresh cycle, and include connection/disconnection messages in server.