### PR TITLE
Run ticker indepently

### DIFF
--- a/.github/workflows/release_orbit.yml
+++ b/.github/workflows/release_orbit.yml
@@ -41,8 +41,6 @@ jobs:
           hugo-version: '0.71.1'
       - name: Build Hugo Docs
         run: hugo -s docs -b /orbit
-      - name: Copy in Chart index.yaml
-        run: cp ./.github/helm/index.yaml ./docs/public/index.yaml
       - name: Publish Artifacts to GitHub Maven Repository
         run: ./.github/scripts/gradle_publish.sh
         env:
@@ -77,13 +75,13 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           MAVEN_URL: ${{ secrets.MAVEN_CENTRAL_URL }}
           ORBIT_VERSION: ${{ github.event.inputs.tag_version }}
-      - name: Commit and Create Release
-        run: ./.github/scripts/create_release.sh
+      - name: Publish Helm Chart to GitHub Repository
+        run: ./.github/scripts/helm_publish.sh
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           TAG_VERSION: ${{ github.event.inputs.tag_version }}
-      - name: Publish Helm Chart to GitHub Repository
-        run: ./.github/scripts/helm_publish.sh
+      - name: Commit and Create Release
+        run: ./.github/scripts/create_release.sh
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           TAG_VERSION: ${{ github.event.inputs.tag_version }}

--- a/src/orbit-client/src/main/kotlin/orbit/client/OrbitClient.kt
+++ b/src/orbit-client/src/main/kotlin/orbit/client/OrbitClient.kt
@@ -52,8 +52,13 @@ class OrbitClient(val config: OrbitClientConfig = OrbitClientConfig()) {
         exceptionHandler = this::onUnhandledException
     )
 
+    private val tickerScope = SupervisorScope(
+        pool = config.tickerPool,
+        exceptionHandler = this::onUnhandledException
+    )
+
     private val ticker = ConstantTicker(
-        scope = scope,
+        scope = tickerScope,
         targetTickRate = config.tickRate.toMillis(),
         clock = clock,
         logger = logger,

--- a/src/orbit-client/src/main/kotlin/orbit/client/OrbitClientConfig.kt
+++ b/src/orbit-client/src/main/kotlin/orbit/client/OrbitClientConfig.kt
@@ -45,6 +45,11 @@ data class OrbitClientConfig(
     val pool: CoroutineDispatcher = Pools.createFixedPool("orbit-client"),
 
     /**
+     * The pool where Orbit ticker will run.
+     */
+    val tickerPool: CoroutineDispatcher = Pools.createFixedPool("orbit-ticker"),
+
+    /**
      * The number of workers that can process a message concurrently.
      */
     val railCount: Int = 128,


### PR DESCRIPTION
Run ticker independently to not interfere with the other threads that are in use.
Also fix the ordering of releasing.